### PR TITLE
Add support for method signature and method matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ hs_err_pid*
 # IntelliJ IDEA project files
 *.ipr
 *.iml
+.idea

--- a/src/main/java/com/github/therapi/runtimejavadoc/MethodJavadoc.java
+++ b/src/main/java/com/github/therapi/runtimejavadoc/MethodJavadoc.java
@@ -1,12 +1,15 @@
 package com.github.therapi.runtimejavadoc;
 
-import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.unmodifiableDefensiveCopy;
-
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.unmodifiableDefensiveCopy;
 
 public class MethodJavadoc {
     private final String name;
-    private final String signature;
+    private final List<String> paramTypes;
     private final Comment comment;
     private final List<ParamJavadoc> params;
     private final List<ThrowsJavadoc> exceptions;
@@ -15,7 +18,7 @@ public class MethodJavadoc {
     private final List<SeeAlsoJavadoc> seeAlso;
 
     public MethodJavadoc(String name,
-                         String signature,
+                         List<String> paramTypes,
                          Comment comment,
                          List<ParamJavadoc> params,
                          List<ThrowsJavadoc> exceptions,
@@ -23,7 +26,7 @@ public class MethodJavadoc {
                          Comment returns,
                          List<SeeAlsoJavadoc> seeAlso) {
         this.name = name;
-        this.signature = signature;
+        this.paramTypes = paramTypes;
         this.comment = comment;
         this.params = unmodifiableDefensiveCopy(params);
         this.exceptions = unmodifiableDefensiveCopy(exceptions);
@@ -32,12 +35,22 @@ public class MethodJavadoc {
         this.seeAlso = unmodifiableDefensiveCopy(seeAlso);
     }
 
+    public boolean matches(Method method) {
+        if (!method.getName().equals(name)) {
+            return false;
+        }
+        List<String> methodParamsTypes = Arrays.stream(method.getParameterTypes())
+                                               .map(Class::getCanonicalName)
+                                               .collect(Collectors.toList());
+        return methodParamsTypes.equals(paramTypes);
+    }
+
     public String getName() {
         return name;
     }
 
-    public String getSignature() {
-        return signature;
+    public List<String> getParamTypes() {
+        return paramTypes;
     }
 
     public Comment getComment() {
@@ -68,7 +81,7 @@ public class MethodJavadoc {
     public String toString() {
         return "MethodJavadoc{" +
                 "name='" + name + '\'' +
-                ", signature='" + signature + '\'' +
+                ", paramTypes='" + paramTypes + '\'' +
                 ", comment=" + comment +
                 ", params=" + params +
                 ", exceptions=" + exceptions +

--- a/src/main/java/com/github/therapi/runtimejavadoc/RuntimeJavadoc.java
+++ b/src/main/java/com/github/therapi/runtimejavadoc/RuntimeJavadoc.java
@@ -1,10 +1,11 @@
 package com.github.therapi.runtimejavadoc;
 
-import static com.github.therapi.runtimejavadoc.internal.JavadocAnnotationProcessor.javadocClassNameSuffix;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Optional;
+
+import static com.github.therapi.runtimejavadoc.internal.JavadocAnnotationProcessor.javadocClassNameSuffix;
 
 public class RuntimeJavadoc {
     private RuntimeJavadoc() {
@@ -31,5 +32,14 @@ public class RuntimeJavadoc {
         } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static Optional<MethodJavadoc> getJavadoc(Method method) {
+        Optional<ClassJavadoc> javadoc = getJavadoc(method.getDeclaringClass());
+        return javadoc.map(ClassJavadoc::getMethods).flatMap(mDocs -> findMethodJavadoc(mDocs, method));
+    }
+
+    private static Optional<MethodJavadoc> findMethodJavadoc(List<MethodJavadoc> methodDocs, Method method) {
+        return methodDocs.stream().filter(m -> m.matches(method)).findAny();
     }
 }

--- a/src/main/java/com/github/therapi/runtimejavadoc/internal/JavadocParser.java
+++ b/src/main/java/com/github/therapi/runtimejavadoc/internal/JavadocParser.java
@@ -13,6 +13,7 @@ import com.github.therapi.runtimejavadoc.OtherJavadoc;
 import com.github.therapi.runtimejavadoc.ParamJavadoc;
 import com.github.therapi.runtimejavadoc.SeeAlsoJavadoc;
 import com.github.therapi.runtimejavadoc.ThrowsJavadoc;
+import com.sun.tools.javadoc.resources.javadoc;
 
 public class JavadocParser {
     public static class ParsedJavadoc {
@@ -71,7 +72,7 @@ public class JavadocParser {
                 otherDocs, new ArrayList<SeeAlsoJavadoc>(), methods);
     }
 
-    public static MethodJavadoc parseMethodJavadoc(String methodName, String javadoc) {
+    public static MethodJavadoc parseMethodJavadoc(String methodName, List<String> paramTypes, String javadoc) {
         ParsedJavadoc parsed = parse(javadoc);
 
         List<OtherJavadoc> otherDocs = new ArrayList<>();
@@ -95,7 +96,7 @@ public class JavadocParser {
             }
         }
 
-        return new MethodJavadoc(methodName, "", parseComment(parsed.getDescription()),
+        return new MethodJavadoc(methodName, paramTypes, parseComment(parsed.getDescription()),
                 paramDocs,
                 new ArrayList<ThrowsJavadoc>(),
                 otherDocs,

--- a/src/test/java/com/github/therapi/runtimejavadoc/Example.java
+++ b/src/test/java/com/github/therapi/runtimejavadoc/Example.java
@@ -30,7 +30,7 @@ public class Example {
         System.out.println("METHODS");
 
         for (MethodJavadoc methodDoc : classDoc.getMethods()) {
-            System.out.println(methodDoc.getName() + methodDoc.getSignature());
+            System.out.println(methodDoc.getName() + methodDoc.getParamTypes());
             System.out.println(format(methodDoc.getComment()));
             System.out.println("  returns " + format(methodDoc.getReturns()));
 

--- a/src/test/java/com/github/therapi/runtimejavadoc/JavadocAnnotationProcessorTest.java
+++ b/src/test/java/com/github/therapi/runtimejavadoc/JavadocAnnotationProcessorTest.java
@@ -4,7 +4,10 @@ import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
 import static org.junit.Assert.assertEquals;
 
+import java.lang.reflect.Method;
 import java.net.URLClassLoader;
+import java.time.LocalDate;
+import java.util.List;
 
 import com.github.therapi.runtimejavadoc.internal.JavadocAnnotationProcessor;
 import com.google.testing.compile.Compilation;
@@ -14,13 +17,18 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class JavadocAnnotationProcessorTest {
+
     private static final String TEST_CLASS_NAME = "javasource.DocumentedClass";
+    private static final String TEST_METHOD_NAME = "frobulate";
     private static final String TEST_CLASS_SRC_RESOURCE_NAME = TEST_CLASS_NAME.replace(".", "/") + ".java";
+
+    // formatters are reusable and thread-safe
+    private static final CommentFormatter formatter = new CommentFormatter();
 
     private static URLClassLoader classLoader;
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         Compilation compilation = javac()
                 .withProcessors(new JavadocAnnotationProcessor())
                 .compile(JavaFileObjects.forResource(TEST_CLASS_SRC_RESOURCE_NAME));
@@ -37,10 +45,30 @@ public class JavadocAnnotationProcessorTest {
 
     @Test
     public void classNameIsPreserved() throws Exception {
-        Class c = classLoader.loadClass(TEST_CLASS_NAME);
+        Class<?> c = classLoader.loadClass(TEST_CLASS_NAME);
+
         ClassJavadoc classJavadoc = RuntimeJavadoc.getJavadoc(c).orElseThrow(
                 () -> new RuntimeException("missing javadoc"));
-
         assertEquals(TEST_CLASS_NAME, classJavadoc.getName());
+    }
+
+    @Test
+    public void methodsMatchDespiteOverload() throws Exception {
+        Class<?> c = classLoader.loadClass(TEST_CLASS_NAME);
+
+        Method m1 = c.getDeclaredMethod(TEST_METHOD_NAME, String.class, int.class);
+        Method m2 = c.getDeclaredMethod(TEST_METHOD_NAME, String.class, List.class);
+
+        assertMethodMatches(m1, "Frobulate {@code a} by {@code b}");
+        assertMethodMatches(m2, "Frobulate {@code a} by multiple oopsifizzle constants");
+    }
+
+    private static void assertMethodMatches(Method method, String expectedDescription) {
+        MethodJavadoc methodDoc = RuntimeJavadoc.getJavadoc(method).orElseThrow(
+                () -> new RuntimeException("method javadoc not found"));
+        assertEquals(method.getName(), methodDoc.getName());
+
+        String actualDesc = formatter.format(methodDoc.getComment());
+        assertEquals(expectedDescription, actualDesc);
     }
 }

--- a/src/test/resources/javasource/DocumentedClass.java
+++ b/src/test/resources/javasource/DocumentedClass.java
@@ -1,5 +1,7 @@
 package javasource;
 
+import java.util.List;
+
 import com.github.therapi.runtimejavadoc.RetainJavadoc;
 
 /**
@@ -22,6 +24,20 @@ public class DocumentedClass {
      * @see #someOtherMethod()
      */
     public int frobulate(String a, int b) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Frobulate {@code a} by multiple oopsifizzle constants
+     *
+     * @param a blurtification factor
+     * @param b oopsifizzle constants
+     * @return {@code a} frobulated by {@code b}
+     * @throws UnsupportedOperationException if frobulation cannot be performed
+     * @see com.github.therapi.runtimejavadoc.DocumentedClass Hey, that's this class!
+     * @see #someOtherMethod()
+     */
+    public int frobulate(String a, List<Integer> b) {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
This PR resolves issue https://github.com/dnault/therapi-runtime-javadoc/issues/5 by providing fully qualified parameter types in `MethodJavadoc`.