### PR TITLE
Add field and enum constants support

### DIFF
--- a/therapi-runtime-javadoc-scribe/src/main/java/com/github/therapi/runtimejavadoc/internal/JavadocAnnotationProcessor.java
+++ b/therapi-runtime-javadoc-scribe/src/main/java/com/github/therapi/runtimejavadoc/internal/JavadocAnnotationProcessor.java
@@ -15,7 +15,6 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.PackageElement;
-import javax.lang.model.element.QualifiedNameable;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
@@ -74,56 +73,6 @@ public class JavadocAnnotationProcessor extends AbstractProcessor {
         }
 
         return false;
-    }
-
-    private static String getPackage(Element e) {
-        while (e.getKind() != ElementKind.PACKAGE) {
-            e = e.getEnclosingElement();
-            if (e == null) {
-                return "";
-            }
-        }
-        return ((QualifiedNameable) e).getQualifiedName().toString();
-    }
-
-    private static class PackageFilter implements Predicate<Element> {
-        private final Set<String> rootPackages = new HashSet<>();
-        private final Set<String> packages = new HashSet<>();
-        private final Set<String> negatives = new HashSet<>();
-
-        private PackageFilter(String commaDelimitedPackages) {
-            for (String pkg : commaDelimitedPackages.split(",")) {
-                pkg = pkg.trim();
-                if (!pkg.isEmpty()) {
-                    rootPackages.add(pkg);
-                }
-            }
-            packages.addAll(rootPackages);
-        }
-
-        @Override
-        public boolean test(Element element) {
-            final String elementPackage = getPackage(element);
-
-            if (negatives.contains(elementPackage)) {
-                return false;
-            }
-
-            if (packages.contains(elementPackage)) {
-                return true;
-            }
-
-            for (String p : rootPackages) {
-                if (elementPackage.startsWith(p + ".")) {
-                    // Element's package is a subpackage of an included package.
-                    packages.add(elementPackage);
-                    return true;
-                }
-            }
-
-            negatives.add(elementPackage);
-            return false;
-        }
     }
 
     private void generateJavadoc(Elements elements, Element e, Set<Element> alreadyProcessed) {

--- a/therapi-runtime-javadoc-scribe/src/main/java/com/github/therapi/runtimejavadoc/internal/JavadocAnnotationProcessor.java
+++ b/therapi-runtime-javadoc-scribe/src/main/java/com/github/therapi/runtimejavadoc/internal/JavadocAnnotationProcessor.java
@@ -120,24 +120,10 @@ public class JavadocAnnotationProcessor extends AbstractProcessor {
                     ) {
                 continue;
             }
-            ExecutableElement executableElement = (ExecutableElement) child;
-
-            String methodJavadoc = elements.getDocComment(executableElement);
-
-            if (isBlank(methodJavadoc)) {
+            JsonObject method = generateMethodJavadoc(elements, (ExecutableElement) child);
+            if (method == null) {
                 continue;
             }
-
-            JsonObject method = new JsonObject();
-
-            String simpleName = executableElement.getSimpleName().toString();
-            method.add(methodNameFieldName(), simpleName);
-
-            JsonArray paramTypes = new JsonArray();
-            getParamErasures(executableElement).forEach(paramTypes::add);
-
-            method.add(paramTypesFieldName(), paramTypes);
-            method.add(methodDocFieldName(), methodJavadoc);
             methods.add(method);
         }
 
@@ -155,6 +141,25 @@ public class JavadocAnnotationProcessor extends AbstractProcessor {
         }
     }
 
+    private JsonObject generateMethodJavadoc(Elements elements, ExecutableElement methodElement) {
+        String methodJavadoc = elements.getDocComment(methodElement);
+
+        if (isBlank(methodJavadoc)) {
+            return null;
+        }
+
+        JsonObject method = new JsonObject();
+
+        String simpleName = methodElement.getSimpleName().toString();
+        method.add(methodNameFieldName(), simpleName);
+
+        JsonArray paramTypes = new JsonArray();
+        getParamErasures(methodElement).forEach(paramTypes::add);
+
+        method.add(paramTypesFieldName(), paramTypes);
+        method.add(methodDocFieldName(), methodJavadoc);
+        return method;
+    }
 
     private static boolean isBlank(String s) {
         return s == null || s.trim().isEmpty();

--- a/therapi-runtime-javadoc-scribe/src/main/java/com/github/therapi/runtimejavadoc/internal/JsonJavadocBuilder.java
+++ b/therapi-runtime-javadoc-scribe/src/main/java/com/github/therapi/runtimejavadoc/internal/JsonJavadocBuilder.java
@@ -1,0 +1,124 @@
+package com.github.therapi.runtimejavadoc.internal;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
+
+import com.eclipsesource.json.Json;
+import com.eclipsesource.json.JsonArray;
+import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonValue;
+
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.elementDocFieldName;
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.elementNameFieldName;
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.enumConstantsFieldName;
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.fieldsFieldName;
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.methodsFieldName;
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.paramTypesFieldName;
+
+class JsonJavadocBuilder {
+
+    private static final Collector<JsonValue, JsonArray, JsonArray> JSON_ARRAY_COLLECTOR = Collector.of(JsonArray::new,
+            JsonArray::add, (arr1, arr2) -> {
+                arr2.forEach(arr1::add);
+                return arr1;
+            });
+
+    private final ProcessingEnvironment processingEnv;
+
+    JsonJavadocBuilder(ProcessingEnvironment processingEnv) {
+        this.processingEnv = processingEnv;
+    }
+
+    Optional<JsonObject> getClassJavadocAsJson(TypeElement classElement) {
+        String classDoc = processingEnv.getElementUtils().getDocComment(classElement);
+
+        if (isBlank(classDoc)) {
+            classDoc = "";
+        }
+
+        Map<ElementKind, List<Element>> children = classElement.getEnclosedElements()
+                                                               .stream()
+                                                               .collect(Collectors.groupingBy(Element::getKind));
+        List<Element> enclosedFields = children.getOrDefault(ElementKind.FIELD, Collections.emptyList());
+        List<Element> enclosedEnumConstants = children.getOrDefault(ElementKind.ENUM_CONSTANT, Collections.emptyList());
+        List<Element> enclosedMethods = children.getOrDefault(ElementKind.METHOD, Collections.emptyList());
+
+        JsonArray fieldDocs = getJavadocsAsJson(enclosedFields, this::getFieldJavadocAsJson);
+        JsonArray enumConstantDocs = getJavadocsAsJson(enclosedEnumConstants, this::getFieldJavadocAsJson);
+        JsonArray methodDocs = getJavadocsAsJson(enclosedMethods, this::getMethodJavadocAsJson);
+
+        if (isBlank(classDoc) && fieldDocs.isEmpty() && enumConstantDocs.isEmpty() && methodDocs.isEmpty()) {
+            return Optional.empty();
+        }
+
+        JsonObject json = new JsonObject();
+        json.add(elementDocFieldName(), classDoc);
+        json.add(fieldsFieldName(), fieldDocs);
+        json.add(enumConstantsFieldName(), enumConstantDocs);
+        json.add(methodsFieldName(), methodDocs);
+        return Optional.of(json);
+    }
+
+    private static JsonArray getJavadocsAsJson(List<Element> elements,
+            Function<Element, Optional<JsonObject>> createDoc) {
+        return elements.stream()
+                       .map(createDoc)
+                       .filter(Optional::isPresent)
+                       .map(Optional::get)
+                       .collect(JSON_ARRAY_COLLECTOR);
+    }
+
+    private Optional<JsonObject> getFieldJavadocAsJson(Element field) {
+        String javadoc = processingEnv.getElementUtils().getDocComment(field);
+        if (isBlank(javadoc)) {
+            return Optional.empty();
+        }
+
+        JsonObject jsonDoc = new JsonObject();
+        jsonDoc.add(elementNameFieldName(), field.getSimpleName().toString());
+        jsonDoc.add(elementDocFieldName(), javadoc);
+        return Optional.of(jsonDoc);
+    }
+
+    private Optional<JsonObject> getMethodJavadocAsJson(Element method) {
+        assert method instanceof ExecutableElement;
+
+        String methodJavadoc = processingEnv.getElementUtils().getDocComment(method);
+        if (isBlank(methodJavadoc)) {
+            return Optional.empty();
+        }
+
+        JsonObject jsonDoc = new JsonObject();
+        jsonDoc.add(elementNameFieldName(), method.getSimpleName().toString());
+        jsonDoc.add(paramTypesFieldName(), getParamErasures((ExecutableElement) method));
+        jsonDoc.add(elementDocFieldName(), methodJavadoc);
+        return Optional.of(jsonDoc);
+    }
+
+    private JsonArray getParamErasures(ExecutableElement executableElement) {
+        Types typeUtils = processingEnv.getTypeUtils();
+        return executableElement.getParameters()
+                                .stream()
+                                .map(Element::asType)
+                                .map(typeUtils::erasure)
+                                .map(TypeMirror::toString)
+                                .map(Json::value)
+                                .collect(JSON_ARRAY_COLLECTOR);
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.trim().isEmpty();
+    }
+}

--- a/therapi-runtime-javadoc-scribe/src/main/java/com/github/therapi/runtimejavadoc/internal/PackageFilter.java
+++ b/therapi-runtime-javadoc-scribe/src/main/java/com/github/therapi/runtimejavadoc/internal/PackageFilter.java
@@ -1,0 +1,59 @@
+package com.github.therapi.runtimejavadoc.internal;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.QualifiedNameable;
+
+class PackageFilter implements Predicate<Element> {
+
+    private final Set<String> rootPackages = new HashSet<>();
+    private final Set<String> packages = new HashSet<>();
+    private final Set<String> negatives = new HashSet<>();
+
+    PackageFilter(String commaDelimitedPackages) {
+        for (String pkg : commaDelimitedPackages.split(",")) {
+            pkg = pkg.trim();
+            if (!pkg.isEmpty()) {
+                rootPackages.add(pkg);
+            }
+        }
+        packages.addAll(rootPackages);
+    }
+
+    @Override
+    public boolean test(Element element) {
+        final String elementPackage = getPackage(element);
+
+        if (negatives.contains(elementPackage)) {
+            return false;
+        }
+
+        if (packages.contains(elementPackage)) {
+            return true;
+        }
+
+        for (String p : rootPackages) {
+            if (elementPackage.startsWith(p + ".")) {
+                // Element's package is a subpackage of an included package.
+                packages.add(elementPackage);
+                return true;
+            }
+        }
+
+        negatives.add(elementPackage);
+        return false;
+    }
+
+    private static String getPackage(Element e) {
+        while (e.getKind() != ElementKind.PACKAGE) {
+            e = e.getEnclosingElement();
+            if (e == null) {
+                return "";
+            }
+        }
+        return ((QualifiedNameable) e).getQualifiedName().toString();
+    }
+}

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/ComplexEnum.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/ComplexEnum.java
@@ -1,0 +1,33 @@
+package javasource.foo;
+
+/**
+ * Hi, I'm a complex enum with fields.
+ */
+public enum ComplexEnum {
+
+    /**
+     * This is the FOO11 value documentation
+     */
+    FOO11("test1"),
+    /**
+     * This is the BAR22 value documentation
+     */
+    BAR22("test2"),
+    /**
+     * This is the BAZ33 value documentation
+     */
+    BAZ33("test3");
+
+    /**
+     * Content field description.
+     */
+    private final String content;
+
+    private ComplexEnum(String content) {
+        this.content = content;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/DocumentedClass.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/DocumentedClass.java
@@ -12,6 +12,13 @@ import java.util.List;
 public class DocumentedClass {
 
   /**
+   * I'm a useful field, maybe.
+   *
+   * @see #frobulate(String, int) interesting method, but nothing to do with this field
+   */
+  private int myField;
+
+  /**
    * Frobulate {@code a} by {@code b}
    *
    * @param a blurtification factor

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/DocumentedEnum.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/DocumentedEnum.java
@@ -1,0 +1,20 @@
+package javasource.foo;
+
+/**
+ * Hi, I'm a documented enum.
+ */
+public enum DocumentedEnum {
+
+    /**
+     * This is the FOO11 value documentation
+     */
+    FOO11,
+    /**
+     * This is the BAR22 value documentation
+     */
+    BAR22,
+    /**
+     * This is the BAZ33 value documentation
+     */
+    BAZ33;
+}

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/BaseJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/BaseJavadoc.java
@@ -1,0 +1,34 @@
+package com.github.therapi.runtimejavadoc;
+
+import java.util.List;
+
+public abstract class BaseJavadoc {
+
+    private final String name;
+    private final Comment comment;
+    private final List<SeeAlsoJavadoc> seeAlso;
+    private final List<OtherJavadoc> other;
+
+    BaseJavadoc(String name, Comment comment, List<SeeAlsoJavadoc> seeAlso, List<OtherJavadoc> other) {
+        this.name = name;
+        this.comment = comment;
+        this.other = other;
+        this.seeAlso = seeAlso;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Comment getComment() {
+        return comment;
+    }
+
+    public List<SeeAlsoJavadoc> getSeeAlso() {
+        return seeAlso;
+    }
+
+    public List<OtherJavadoc> getOther() {
+        return other;
+    }
+}

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/ClassJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/ClassJavadoc.java
@@ -1,42 +1,29 @@
 package com.github.therapi.runtimejavadoc;
 
-import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.unmodifiableDefensiveCopy;
-
 import java.util.List;
 
-public class ClassJavadoc {
-    private final String name;
-    private final Comment comment;
-    private final List<SeeAlsoJavadoc> seeAlso;
-    private final List<OtherJavadoc> other;
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.unmodifiableDefensiveCopy;
+
+public class ClassJavadoc extends BaseJavadoc {
+
+    private final List<FieldJavadoc> fields;
+    private final List<FieldJavadoc> enumConstants;
     private final List<MethodJavadoc> methods;
 
-    public ClassJavadoc(String name,
-                        Comment comment,
-                        List<OtherJavadoc> other,
-                        List<SeeAlsoJavadoc> seeAlso,
-                        List<MethodJavadoc> methods) {
-        this.name = name;
-        this.comment = comment;
-        this.other = unmodifiableDefensiveCopy(other);
-        this.seeAlso = unmodifiableDefensiveCopy(seeAlso);
+    public ClassJavadoc(String name, Comment comment, List<FieldJavadoc> fields, List<FieldJavadoc> enumConstants,
+            List<MethodJavadoc> methods, List<OtherJavadoc> other, List<SeeAlsoJavadoc> seeAlso) {
+        super(name, comment, seeAlso, other);
+        this.fields = unmodifiableDefensiveCopy(fields);
+        this.enumConstants = unmodifiableDefensiveCopy(enumConstants);
         this.methods = unmodifiableDefensiveCopy(methods);
     }
 
-    public String getName() {
-        return name;
+    public List<FieldJavadoc> getFields() {
+        return fields;
     }
 
-    public Comment getComment() {
-        return comment;
-    }
-
-    public List<SeeAlsoJavadoc> getSeeAlso() {
-        return seeAlso;
-    }
-
-    public List<OtherJavadoc> getOther() {
-        return other;
+    public List<FieldJavadoc> getEnumConstants() {
+        return enumConstants;
     }
 
     public List<MethodJavadoc> getMethods() {
@@ -46,11 +33,12 @@ public class ClassJavadoc {
     @Override
     public String toString() {
         return "ClassJavadoc{" +
-                "name='" + name + '\'' +
-                ", comment=" + comment +
-                ", seeAlso=" + seeAlso +
-                ", other=" + other +
+                "name='" + getName() + '\'' +
+                ", comment=" + getComment() +
+                ", fields=" + fields +
                 ", methods=" + methods +
+                ", seeAlso=" + getSeeAlso() +
+                ", other=" + getOther() +
                 '}';
     }
 }

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/FieldJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/FieldJavadoc.java
@@ -1,0 +1,20 @@
+package com.github.therapi.runtimejavadoc;
+
+import java.util.List;
+
+public class FieldJavadoc extends BaseJavadoc {
+
+    public FieldJavadoc(String name, Comment comment, List<OtherJavadoc> other, List<SeeAlsoJavadoc> seeAlso) {
+        super(name, comment, seeAlso, other);
+    }
+
+    @Override
+    public String toString() {
+        return "FieldJavadoc{"
+                + "name='" + getName() + '\''
+                + ", comment=" + getComment()
+                + ", other=" + getOther()
+                + ", seeAlso=" + getSeeAlso()
+                + '}';
+    }
+}

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/RuntimeJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/RuntimeJavadoc.java
@@ -1,8 +1,5 @@
 package com.github.therapi.runtimejavadoc;
 
-import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.javadocResourceSuffix;
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -15,20 +12,53 @@ import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
 import com.github.therapi.runtimejavadoc.internal.JsonJavadocReader;
 
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.javadocResourceSuffix;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Allows access to Javadoc elements at runtime. This will only find the Javadoc of elements that were processed by
+ * the annotation processor.
+ */
 public class RuntimeJavadoc {
 
     private RuntimeJavadoc() {
         throw new AssertionError("not instantiable");
     }
 
-    public static Optional<ClassJavadoc> getJavadoc(Class c) {
-        return getJavadoc(c.getName(), c);
+    /**
+     * Gets the Javadoc of the given class.
+     *
+     * @param clazz
+     *         the class to retrieve the Javadoc for
+     *
+     * @return the Javadoc of the given class, or an empty optional if no documentation was found
+     */
+    public static Optional<ClassJavadoc> getJavadoc(Class clazz) {
+        return getJavadoc(clazz.getName(), clazz);
     }
 
+    /**
+     * Gets the Javadoc of the given class.
+     *
+     * @param qualifiedClassName
+     *         the fully qualified name of the class to retrieve the Javadoc for
+     *
+     * @return the Javadoc of the given class, or an empty optional if no documentation was found
+     */
     public static Optional<ClassJavadoc> getJavadoc(String qualifiedClassName) {
         return getJavadoc(qualifiedClassName, RuntimeJavadoc.class);
     }
 
+    /**
+     * Gets the Javadoc of the given class, using the given {@link ClassLoader} to find the Javadoc resource.
+     *
+     * @param qualifiedClassName
+     *         the fully qualified name of the class to retrieve the Javadoc for
+     * @param classLoader
+     *         the class loader to use to find the Javadoc resource file
+     *
+     * @return the Javadoc of the given class, or an empty optional if no documentation was found
+     */
     public static Optional<ClassJavadoc> getJavadoc(String qualifiedClassName, ClassLoader classLoader) {
         final String resourceName = getResourceName(qualifiedClassName);
         try (InputStream is = classLoader.getResourceAsStream(resourceName)) {
@@ -38,6 +68,16 @@ public class RuntimeJavadoc {
         }
     }
 
+    /**
+     * Gets the Javadoc of the given class, using the given {@link Class} object to load the Javadoc resource.
+     *
+     * @param qualifiedClassName
+     *         the fully qualified name of the class to retrieve the Javadoc for
+     * @param loader
+     *         the class object to use to find the Javadoc resource file
+     *
+     * @return the Javadoc of the given class, or an empty optional if no documentation was found
+     */
     public static Optional<ClassJavadoc> getJavadoc(String qualifiedClassName, Class loader) {
         final String resourceName = getResourceName(qualifiedClassName);
         try (InputStream is = loader.getResourceAsStream("/" + resourceName)) {
@@ -62,6 +102,19 @@ public class RuntimeJavadoc {
         }
     }
 
+    /**
+     * Gets the Javadoc of the given method.
+     * <p>
+     * Implementation note: this method first retrieves the Javadoc of the class, and then matches the method signature
+     * with the correct documentation. If the client code's purpose is to loop through all methods doc, prefer using
+     * {@link #getJavadoc(Class)} (or one of its overloads), and calling {@link ClassJavadoc#getMethods()} on the
+     * returned class doc to retrieve method docs.
+     *
+     * @param method
+     *         the method to get the Javadoc for
+     *
+     * @return the given method's Javadoc, or an empty optional if no documentation was found
+     */
     public static Optional<MethodJavadoc> getJavadoc(Method method) {
         Optional<ClassJavadoc> javadoc = getJavadoc(method.getDeclaringClass());
         return javadoc.map(ClassJavadoc::getMethods).flatMap(mDocs -> findMethodJavadoc(mDocs, method));
@@ -71,6 +124,19 @@ public class RuntimeJavadoc {
         return methodDocs.stream().filter(m -> m.matches(method)).findAny();
     }
 
+    /**
+     * Gets the Javadoc of the given field.
+     * <p>
+     * Implementation note: this method first retrieves the Javadoc of the class, and then matches the field name
+     * with the correct documentation. If the client code's purpose is to loop through all fields doc, prefer using
+     * {@link #getJavadoc(Class)} (or one of its overloads), and calling {@link ClassJavadoc#getFields()} on the
+     * returned class doc to retrieve field docs.
+     *
+     * @param field
+     *         the field to get the Javadoc for
+     *
+     * @return the given field's Javadoc, or an empty optional if no documentation was found
+     */
     public static Optional<FieldJavadoc> getJavadoc(Field field) {
         Optional<ClassJavadoc> javadoc = getJavadoc(field.getDeclaringClass());
         return javadoc.map(ClassJavadoc::getFields).flatMap(fDocs -> findFieldJavadoc(fDocs, field));
@@ -80,6 +146,19 @@ public class RuntimeJavadoc {
         return fieldDocs.stream().filter(m -> m.getName().equals(field.getName())).findAny();
     }
 
+    /**
+     * Gets the Javadoc of the given enum constant.
+     * <p>
+     * Implementation note: this method first retrieves the Javadoc of the class, and then matches the enum constant's
+     * name with the correct documentation. If the client code's purpose is to loop through all enum constants docs,
+     * prefer using {@link #getJavadoc(Class)} (or one of its overloads), and calling
+     * {@link ClassJavadoc#getEnumConstants()} on the returned class doc to retrieve enum constant docs.
+     *
+     * @param enumValue
+     *         the enum constant to get the Javadoc for
+     *
+     * @return the given enum constant's Javadoc, or an empty optional if no documentation was found
+     */
     public static Optional<FieldJavadoc> getJavadoc(Enum<?> enumValue) {
         Optional<ClassJavadoc> javadoc = getJavadoc(enumValue.getDeclaringClass());
         return javadoc.map(ClassJavadoc::getEnumConstants).flatMap(fDocs -> findEnumValueJavadoc(fDocs, enumValue));

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/JsonJavadocReader.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/JsonJavadocReader.java
@@ -1,0 +1,75 @@
+package com.github.therapi.runtimejavadoc.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.eclipsesource.json.JsonArray;
+import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonValue;
+import com.github.therapi.runtimejavadoc.ClassJavadoc;
+import com.github.therapi.runtimejavadoc.FieldJavadoc;
+import com.github.therapi.runtimejavadoc.MethodJavadoc;
+
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.elementDocFieldName;
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.elementNameFieldName;
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.enumConstantsFieldName;
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.fieldsFieldName;
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.methodsFieldName;
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.paramTypesFieldName;
+
+public class JsonJavadocReader {
+
+    public static Optional<ClassJavadoc> readClassJavadoc(String qualifiedClassName, JsonObject json) {
+        String className = qualifiedClassName.replace("$", ".");
+        List<FieldJavadoc> fields = readFieldDocs(json.get(fieldsFieldName()));
+        List<FieldJavadoc> enumConstants = readFieldDocs(json.get(enumConstantsFieldName()));
+        List<MethodJavadoc> methods = readMethodDocs(json.get(methodsFieldName()));
+        String classJavadocString = json.getString(elementDocFieldName(), null);
+        ClassJavadoc classJavadoc = JavadocParser.parseClassJavadoc(className, classJavadocString, fields,
+                enumConstants, methods);
+        return Optional.of(classJavadoc);
+    }
+
+    private static List<FieldJavadoc> readFieldDocs(JsonValue fieldsValue) {
+        JsonArray fieldsArray = fieldsValue.asArray();
+        List<FieldJavadoc> fields = new ArrayList<>(fieldsArray.size());
+        for (JsonValue fieldValue : fieldsArray) {
+            fields.add(readFieldDoc(fieldValue));
+        }
+        return fields;
+    }
+
+    private static FieldJavadoc readFieldDoc(JsonValue fieldValue) {
+        JsonObject field = fieldValue.asObject();
+        String fieldName = field.getString(elementNameFieldName(), null);
+        String fieldDoc = field.getString(elementDocFieldName(), null);
+        return JavadocParser.parseFieldJavadoc(fieldName, fieldDoc);
+    }
+
+    private static List<MethodJavadoc> readMethodDocs(JsonValue methodsValue) {
+        JsonArray methodArray = methodsValue.asArray();
+        List<MethodJavadoc> methods = new ArrayList<>(methodArray.size());
+        for (JsonValue methodValue : methodArray) {
+            methods.add(readMethodDoc(methodValue));
+        }
+        return methods;
+    }
+
+    private static MethodJavadoc readMethodDoc(JsonValue methodValue) {
+        JsonObject method = methodValue.asObject();
+        String methodName = method.getString(elementNameFieldName(), null);
+        List<String> paramTypes = readParamTypes(method.get(paramTypesFieldName()));
+        String methodDoc = method.getString(elementDocFieldName(), null);
+        return JavadocParser.parseMethodJavadoc(methodName, paramTypes, methodDoc);
+    }
+
+    private static List<String> readParamTypes(JsonValue paramTypesValue) {
+        JsonArray paramTypesArray = paramTypesValue.asArray();
+        List<String> paramTypes = new ArrayList<>(paramTypesArray.size());
+        for (JsonValue v : paramTypesArray) {
+            paramTypes.add(v.asString());
+        }
+        return paramTypes;
+    }
+}

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/JsonJavadocReader.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/JsonJavadocReader.java
@@ -1,6 +1,7 @@
 package com.github.therapi.runtimejavadoc.internal;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,6 +33,10 @@ public class JsonJavadocReader {
     }
 
     private static List<FieldJavadoc> readFieldDocs(JsonValue fieldsValue) {
+        if (fieldsValue == null) {
+            // old versions might not have this JSON field
+            return Collections.emptyList();
+        }
         JsonArray fieldsArray = fieldsValue.asArray();
         List<FieldJavadoc> fields = new ArrayList<>(fieldsArray.size());
         for (JsonValue fieldValue : fieldsArray) {

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/RuntimeJavadocHelper.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/RuntimeJavadocHelper.java
@@ -23,19 +23,24 @@ public class RuntimeJavadocHelper {
         return "paramTypes";
     }
 
+    public static String fieldsFieldName() {
+        return "fields";
+    }
+
+    public static String enumConstantsFieldName() {
+        return "enumConstants";
+    }
+
     public static String methodsFieldName() {
         return "methods";
     }
 
-    public static String classDocFieldName() {
-        return "doc";
-    }
-
-    public static String methodDocFieldName() {
-        return "doc";
-    }
-
-    public static String methodNameFieldName() {
+    public static String elementNameFieldName() {
         return "name";
     }
+
+    public static String elementDocFieldName() {
+        return "doc";
+    }
+
 }


### PR DESCRIPTION
This PR adds support for fields and enum constants by adding the resource modifications in the javadoc scribe and providing access through the `RuntimeJavadoc` class.

Some refactoring was performed, mostly on the annotation processor. Please read commits individually to see the steps of the refactoring more easily.

In particular, the `PackageFilter` and `JsonJavadocBuilder` classes were extracted from the processor to separate concerns. That's why I suggest reading resulting files rather than the diff, because the diff will be very hard to understand (it is, even for me who wrote the code).

Also, I extracted some fields from `ClassJavadoc` into a parent `BaseJavadoc` class, to reuse them in the newly created `FieldJavadoc`. I haven't created a separate class such as `EnumConstantJavadoc` because enum constants didn't need anything other than what the `FieldJavadoc` already had. 
This could be added later if need be, although one could argue that an empty class `EnumConstantJavadoc` extending `BaseJavadoc` would allow better backwards compatibility if we later need it.
That being said, I don't believe we will ever need anything more than fields, because, well, enum constants are just fields technically.

Resolves:
https://github.com/dnault/therapi-runtime-javadoc/issues/11