### PR TITLE
Add Comment structure with links and tags

### DIFF
--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/CommentText.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/CommentText.java
@@ -1,5 +1,7 @@
 package com.github.therapi.runtimejavadoc;
 
+import java.util.Objects;
+
 public class CommentText extends CommentElement {
     private final String value;
 
@@ -9,5 +11,27 @@ public class CommentText extends CommentElement {
 
     public String getValue() {
         return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CommentText that = (CommentText) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return "CommentText{" + "value='" + value + '\'' + '}';
     }
 }

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/InlineLink.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/InlineLink.java
@@ -1,5 +1,7 @@
 package com.github.therapi.runtimejavadoc;
 
+import java.util.Objects;
+
 public class InlineLink extends CommentElement {
     private final Link link;
 
@@ -9,5 +11,22 @@ public class InlineLink extends CommentElement {
 
     public Link getLink() {
         return link;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        InlineLink that = (InlineLink) o;
+        return Objects.equals(link, that.link);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(link);
     }
 }

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/InlineTag.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/InlineTag.java
@@ -1,5 +1,7 @@
 package com.github.therapi.runtimejavadoc;
 
+import java.util.Objects;
+
 public class InlineTag extends CommentElement {
     private final String name;
     private final String value;
@@ -15,5 +17,22 @@ public class InlineTag extends CommentElement {
 
     public String getValue() {
         return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        InlineTag inlineTag = (InlineTag) o;
+        return Objects.equals(name, inlineTag.name) && Objects.equals(value, inlineTag.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, value);
     }
 }

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/Link.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/Link.java
@@ -1,5 +1,7 @@
 package com.github.therapi.runtimejavadoc;
 
+import java.util.Objects;
+
 public class Link {
     private final String label;
     private final String referencedClassName;
@@ -21,6 +23,24 @@ public class Link {
 
     public String getReferencedMemberName() {
         return referencedMemberName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Link link = (Link) o;
+        return Objects.equals(label, link.label) && Objects.equals(referencedClassName, link.referencedClassName)
+                && Objects.equals(referencedMemberName, link.referencedMemberName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(label, referencedClassName, referencedMemberName);
     }
 
     public String toString() {

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/JsonJavadocReader.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/JsonJavadocReader.java
@@ -11,6 +11,7 @@ import com.eclipsesource.json.JsonValue;
 import com.github.therapi.runtimejavadoc.ClassJavadoc;
 import com.github.therapi.runtimejavadoc.FieldJavadoc;
 import com.github.therapi.runtimejavadoc.MethodJavadoc;
+import com.github.therapi.runtimejavadoc.internal.parser.JavadocParser;
 
 import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.elementDocFieldName;
 import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.elementNameFieldName;

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/BlockTag.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/BlockTag.java
@@ -1,0 +1,18 @@
+package com.github.therapi.runtimejavadoc.internal.parser;
+
+public class BlockTag {
+
+    final String name;
+
+    final String value;
+
+    public BlockTag(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return "@" + name + " : " + value;
+    }
+}

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/CommentParser.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/CommentParser.java
@@ -15,7 +15,7 @@ import com.github.therapi.runtimejavadoc.Link;
 
 class CommentParser {
 
-    private static final Pattern inlineTag = Pattern.compile("\\{@(\\w+)\\s+(\\w[^}]+)}");
+    private static final Pattern inlineTag = Pattern.compile("\\{@(\\w+)(?:\\s+(\\w[^}]+)?)?}");
 
     private static final Pattern whitespace = Pattern.compile("\\s+");
 

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/CommentParser.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/CommentParser.java
@@ -21,16 +21,11 @@ class CommentParser {
 
     private static final Pattern linkRefSplitter = Pattern.compile("#");
 
-    private static final Comment EMPTY_COMMENT = new Comment(Collections.singletonList(new CommentText("")));
-
     static Comment parse(String commentText) {
-        if (commentText == null) {
+        if (commentText == null || commentText.trim().isEmpty()) {
             return null;
         }
-        if (commentText.isEmpty()) {
-            return EMPTY_COMMENT;
-        }
-        return new Comment(parseElements(commentText));
+        return new Comment(parseElements(commentText.trim()));
     }
 
     private static List<CommentElement> parseElements(String commentText) {

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/CommentParser.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/CommentParser.java
@@ -1,0 +1,84 @@
+package com.github.therapi.runtimejavadoc.internal.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.github.therapi.runtimejavadoc.Comment;
+import com.github.therapi.runtimejavadoc.CommentElement;
+import com.github.therapi.runtimejavadoc.CommentText;
+import com.github.therapi.runtimejavadoc.InlineLink;
+import com.github.therapi.runtimejavadoc.InlineTag;
+import com.github.therapi.runtimejavadoc.Link;
+
+class CommentParser {
+
+    private static final Pattern inlineTag = Pattern.compile("\\{@(\\w+)\\s+(\\w[^}]+)\\}");
+
+    private static final Pattern inlineTagSplitter = Pattern.compile("((?=(\\{@))|(?<=}))");
+
+    private static final Pattern whitespace = Pattern.compile("\\s+");
+
+    private static final Pattern linkRefSplitter = Pattern.compile("#");
+
+    static Comment parse(String commentText) {
+        String[] parts = inlineTagSplitter.split(commentText);
+
+        List<CommentElement> elements = new ArrayList<>();
+        for (String part : parts) {
+            CommentElement elt = parseElement(part);
+
+            if (elt instanceof CommentText) {
+                CommentElement last = last(elements);
+                if (last instanceof CommentText) {
+                    CommentText merged = merge((CommentText) last, (CommentText) elt);
+                    elements.set(elements.size() - 1, merged);
+                    continue;
+                }
+            }
+
+            elements.add(elt);
+        }
+        return new Comment(elements);
+    }
+
+    private static CommentElement parseElement(String elt) {
+        Matcher matcher = inlineTag.matcher(elt);
+        if (matcher.matches()) {
+            return createTagElement(matcher.group(1), matcher.group(2));
+        } else {
+            return new CommentText(elt);
+        }
+    }
+
+    private static CommentElement createTagElement(String name, String value) {
+        if ("link".equals(name)) {
+            return createLinkElement(value);
+        }
+        return new InlineTag(name, value);
+    }
+
+    private static InlineLink createLinkElement(String value) {
+        String[] linkElts = whitespace.split(value, 2);
+        String label = linkElts.length > 1 ? linkElts[1] : linkElts[0];
+
+        String[] ref = linkRefSplitter.split(linkElts[0], 2);
+        String classRef = ref[0];
+        String memberRef = ref.length > 1 ? ref[1] : null;
+
+        Link link = new Link(label, classRef, memberRef);
+        return new InlineLink(link);
+    }
+
+    private static CommentElement last(List<CommentElement> elements) {
+        if (elements.isEmpty()) {
+            return null;
+        }
+        return elements.get(elements.size() - 1);
+    }
+
+    private static CommentText merge(CommentText left, CommentText right) {
+        return new CommentText(left.getValue() + right.getValue());
+    }
+}

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/JavadocParser.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/JavadocParser.java
@@ -6,8 +6,6 @@ import java.util.regex.Pattern;
 
 import com.github.therapi.runtimejavadoc.ClassJavadoc;
 import com.github.therapi.runtimejavadoc.Comment;
-import com.github.therapi.runtimejavadoc.CommentElement;
-import com.github.therapi.runtimejavadoc.CommentText;
 import com.github.therapi.runtimejavadoc.FieldJavadoc;
 import com.github.therapi.runtimejavadoc.MethodJavadoc;
 import com.github.therapi.runtimejavadoc.OtherJavadoc;
@@ -19,12 +17,6 @@ public class JavadocParser {
 
     private static final Pattern whitespace = Pattern.compile("\\s");
 
-    private static Comment parseComment(String s) {
-        List<CommentElement> commentElements = new ArrayList<>();
-        commentElements.add(new CommentText(s));
-        return new Comment(commentElements);
-    }
-
     public static ClassJavadoc parseClassJavadoc(String className, String javadoc, List<FieldJavadoc> fields,
             List<FieldJavadoc> enumConstants, List<MethodJavadoc> methods) {
         ParsedJavadoc parsed = parse(javadoc);
@@ -32,10 +24,10 @@ public class JavadocParser {
         List<OtherJavadoc> otherDocs = new ArrayList<>();
 
         for (BlockTag t : parsed.getBlockTags()) {
-            otherDocs.add(new OtherJavadoc(t.name, parseComment(t.value)));
+            otherDocs.add(new OtherJavadoc(t.name, CommentParser.parse(t.value)));
         }
 
-        return new ClassJavadoc(className, parseComment(parsed.getDescription()), fields, enumConstants, methods,
+        return new ClassJavadoc(className, CommentParser.parse(parsed.getDescription()), fields, enumConstants, methods,
                 otherDocs, new ArrayList<>());
     }
 
@@ -44,10 +36,10 @@ public class JavadocParser {
 
         List<OtherJavadoc> otherDocs = new ArrayList<>();
         for (BlockTag t : parsed.getBlockTags()) {
-            otherDocs.add(new OtherJavadoc(t.name, parseComment(t.value)));
+            otherDocs.add(new OtherJavadoc(t.name, CommentParser.parse(t.value)));
         }
 
-        return new FieldJavadoc(fieldName, parseComment(parsed.getDescription()), otherDocs, new ArrayList<>());
+        return new FieldJavadoc(fieldName, CommentParser.parse(parsed.getDescription()), otherDocs, new ArrayList<>());
     }
 
     public static MethodJavadoc parseMethodJavadoc(String methodName, List<String> paramTypes, String javadoc) {
@@ -64,15 +56,15 @@ public class JavadocParser {
                 String paramName = paramNameAndComment[0];
                 String paramComment = paramNameAndComment.length == 1 ? "" :paramNameAndComment[1];
 
-                paramDocs.add(new ParamJavadoc(paramName, parseComment(paramComment)));
+                paramDocs.add(new ParamJavadoc(paramName, CommentParser.parse(paramComment)));
             } else if (t.name.equals("return")) {
-                returns = parseComment(t.value);
+                returns = CommentParser.parse(t.value);
             } else {
-                otherDocs.add(new OtherJavadoc(t.name, parseComment(t.value)));
+                otherDocs.add(new OtherJavadoc(t.name, CommentParser.parse(t.value)));
             }
         }
 
-        return new MethodJavadoc(methodName, paramTypes, parseComment(parsed.getDescription()), paramDocs,
+        return new MethodJavadoc(methodName, paramTypes, CommentParser.parse(parsed.getDescription()), paramDocs,
                 new ArrayList<>(), otherDocs, returns, new ArrayList<>());
     }
 

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/JavadocParser.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/JavadocParser.java
@@ -1,4 +1,4 @@
-package com.github.therapi.runtimejavadoc.internal;
+package com.github.therapi.runtimejavadoc.internal.parser;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,42 +14,10 @@ import com.github.therapi.runtimejavadoc.OtherJavadoc;
 import com.github.therapi.runtimejavadoc.ParamJavadoc;
 
 public class JavadocParser {
-    public static class ParsedJavadoc {
-        String description;
-        List<BlockTag> blockTags = new ArrayList<>();
 
-        @Override
-        public String toString() {
-            return "ParsedJavadoc{" +
-                    "description='" + description + '\'' +
-                    ", blockTags=" + blockTags +
-                    '}';
-        }
+    private static final Pattern blockSeparator = Pattern.compile("^\\s*@(?=\\S)", Pattern.MULTILINE);
 
-        public String getDescription() {
-            return description;
-        }
-
-        public List<BlockTag> getBlockTags() {
-            return blockTags;
-        }
-    }
-
-    public static class BlockTag {
-        BlockTag(String nameAndValue) {
-            String[] s = whitespace.split(nameAndValue, 2);
-            name = s[0];
-            value = s.length > 1 ? s[1] : "";
-        }
-
-        final String name;
-        final String value;
-
-        @Override
-        public String toString() {
-            return "@" + name + " : " + value;
-        }
-    }
+    private static final Pattern whitespace = Pattern.compile("\\s");
 
     private static Comment parseComment(String s) {
         List<CommentElement> commentElements = new ArrayList<>();
@@ -108,18 +76,22 @@ public class JavadocParser {
                 new ArrayList<>(), otherDocs, returns, new ArrayList<>());
     }
 
-    private static final Pattern blockSeparator = Pattern.compile("^\\s*@(?=\\S)", Pattern.MULTILINE);
-    private static final Pattern whitespace = Pattern.compile("\\s");
-
-    public static ParsedJavadoc parse(String javadoc) {
+    private static ParsedJavadoc parse(String javadoc) {
         String[] blocks = blockSeparator.split(javadoc);
 
         ParsedJavadoc result = new ParsedJavadoc();
         result.description = blocks[0].trim();
 
         for (int i = 1; i < blocks.length; i++) {
-            result.blockTags.add(new BlockTag(blocks[i].trim()));
+            result.blockTags.add(parseBlockTag(blocks[i]));
         }
         return result;
+    }
+
+    private static BlockTag parseBlockTag(String block) {
+        String[] s = whitespace.split(block.trim(), 2);
+        String name = s[0];
+        String value = s.length > 1 ? s[1] : "";
+        return new BlockTag(name, value);
     }
 }

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/ParsedJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/ParsedJavadoc.java
@@ -1,0 +1,27 @@
+package com.github.therapi.runtimejavadoc.internal.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ParsedJavadoc {
+
+    String description;
+
+    List<BlockTag> blockTags = new ArrayList<>();
+
+    @Override
+    public String toString() {
+        return "ParsedJavadoc{" +
+                "description='" + description + '\'' +
+                ", blockTags=" + blockTags +
+                '}';
+    }
+
+    String getDescription() {
+        return description;
+    }
+
+    List<BlockTag> getBlockTags() {
+        return blockTags;
+    }
+}

--- a/therapi-runtime-javadoc/src/test/java/com/github/therapi/runtimejavadoc/internal/parser/CommentParserTest.java
+++ b/therapi-runtime-javadoc/src/test/java/com/github/therapi/runtimejavadoc/internal/parser/CommentParserTest.java
@@ -1,0 +1,110 @@
+package com.github.therapi.runtimejavadoc.internal.parser;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import com.github.therapi.runtimejavadoc.CommentElement;
+import com.github.therapi.runtimejavadoc.CommentText;
+import com.github.therapi.runtimejavadoc.InlineLink;
+import com.github.therapi.runtimejavadoc.InlineTag;
+import com.github.therapi.runtimejavadoc.Link;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Theories.class)
+public class CommentParserTest {
+
+    @DataPoints
+    public static String[] textOnlyData() {
+        return new String[] {
+                "", " ", "\t\n", "abcdef", "abc def\nxyz", "abc}def"
+        };
+    }
+
+    @Theory
+    public void parse_textOnly(String text) {
+        List<CommentElement> elements = CommentParser.parse(text).getElements();
+        assertEquals(1, elements.size());
+        assertEquals(new CommentText(text), elements.get(0));
+    }
+
+    @Test
+    public void parse_linkOnly_simpleLink() {
+        List<CommentElement> elements = CommentParser.parse("{@link ClassName}").getElements();
+        assertEquals(1, elements.size());
+        assertEquals(new InlineLink(new Link("ClassName", "ClassName", null)), elements.get(0));
+    }
+
+    @Test
+    public void parse_linkOnly_labeledLink_noWhiteSpace() {
+        List<CommentElement> elements = CommentParser.parse("{@link ClassName myLabel}").getElements();
+        assertEquals(1, elements.size());
+        assertEquals(new InlineLink(new Link("myLabel", "ClassName", null)), elements.get(0));
+    }
+
+    @Test
+    public void parse_linkOnly_labeledLink_withWhiteSpace() {
+        List<CommentElement> elements = CommentParser.parse("{@link ClassName my label}").getElements();
+        assertEquals(1, elements.size());
+        assertEquals(new InlineLink(new Link("my label", "ClassName", null)), elements.get(0));
+    }
+
+    @Test
+    public void parse_linkOnly_linkWithMemberRef() {
+        List<CommentElement> elements = CommentParser.parse("{@link ClassName#member}").getElements();
+        assertEquals(1, elements.size());
+        assertEquals(new InlineLink(new Link("ClassName#member", "ClassName", "member")), elements.get(0));
+    }
+
+    @Test
+    public void parse_linkOnly_labeledLinkWithMemberRef() {
+        List<CommentElement> elements = CommentParser.parse("{@link ClassName#member label}").getElements();
+        assertEquals(1, elements.size());
+        assertEquals(new InlineLink(new Link("label", "ClassName", "member")), elements.get(0));
+    }
+
+    @Test
+    public void parse_tagOnly_noWhiteSpace() {
+        List<CommentElement> elements = CommentParser.parse("{@sometag someValue}").getElements();
+        assertEquals(1, elements.size());
+        assertEquals(new InlineTag("sometag", "someValue"), elements.get(0));
+    }
+
+    @Test
+    public void parse_tagOnly_withWhiteSpace() {
+        List<CommentElement> elements = CommentParser.parse("{@sometag some value}").getElements();
+        assertEquals(1, elements.size());
+        assertEquals(new InlineTag("sometag", "some value"), elements.get(0));
+    }
+
+    @Test
+    public void parse_mix_textAndTag() {
+        List<CommentElement> elements = CommentParser.parse("text before {@sometag some value}").getElements();
+        assertEquals(2, elements.size());
+        assertEquals(new CommentText("text before "), elements.get(0));
+        assertEquals(new InlineTag("sometag", "some value"), elements.get(1));
+    }
+
+    @Test
+    public void parse_mix_textAndLink() {
+        List<CommentElement> elements = CommentParser.parse("text before {@link ClassName} text after").getElements();
+        assertEquals(3, elements.size());
+        assertEquals(new CommentText("text before "), elements.get(0));
+        assertEquals(new InlineLink(new Link("ClassName", "ClassName", null)), elements.get(1));
+        assertEquals(new CommentText(" text after"), elements.get(2));
+    }
+
+    @Test
+    public void parse_mix_textAndLink_withWeirdBraces() {
+        List<CommentElement> elements = CommentParser.parse("text}before {@link ClassName} text{after").getElements();
+        assertEquals(3, elements.size());
+        assertEquals(new CommentText("text}before "), elements.get(0));
+        assertEquals(new InlineLink(new Link("ClassName", "ClassName", null)), elements.get(1));
+        assertEquals(new CommentText(" text{after"), elements.get(2));
+    }
+}

--- a/therapi-runtime-javadoc/src/test/java/com/github/therapi/runtimejavadoc/internal/parser/CommentParserTest.java
+++ b/therapi-runtime-javadoc/src/test/java/com/github/therapi/runtimejavadoc/internal/parser/CommentParserTest.java
@@ -100,6 +100,15 @@ public class CommentParserTest {
     }
 
     @Test
+    public void parse_mix_textAndLink_realLife() {
+        List<CommentElement> elements = CommentParser.parse("Adds the given {@link Action}s to the queue.").getElements();
+        assertEquals(3, elements.size());
+        assertEquals(new CommentText("Adds the given "), elements.get(0));
+        assertEquals(new InlineLink(new Link("Action", "Action", null)), elements.get(1));
+        assertEquals(new CommentText("s to the queue."), elements.get(2));
+    }
+
+    @Test
     public void parse_mix_textAndLink_withWeirdBraces() {
         List<CommentElement> elements = CommentParser.parse("text}before {@link ClassName} text{after").getElements();
         assertEquals(3, elements.size());


### PR DESCRIPTION
This pull request implements a `CommentParser` responsible for creating a structure `Comment` object with pure `CommentText`s,  `InlineLink`s,  and more general `InlineTag`s.

The addition of `equals` and `hashcode` methods was only useful for writing tests more easily. They could be removed by changing how the tests are made, but I believe they don't hurt, and on the contrary they may be valuable later for clients of this lib too.

A next step would be to actually access imports, so that we could return `InlineLink`s with actual `Class` objects instead of class names.

Resolves:
https://github.com/dnault/therapi-runtime-javadoc/issues/17