### PR TITLE
backported project to Java 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,16 +13,18 @@ subprojects { subproject ->
     version = "0.6.0"
 
     repositories {
+        mavenLocal()
         jcenter()
     }
 
     dependencies {
         compile 'com.eclipsesource.minimal-json:minimal-json:0.9.5'
+        compile 'com.google.code.findbugs:jsr305:3.0.2'
         testCompile 'junit:junit:4.12'
     }
 
-    sourceCompatibility = 1.8
-    targetCompatibility = 1.8
+    sourceCompatibility = 1.7
+    targetCompatibility = 1.7
 
     shadowJar {
         classifier = null

--- a/therapi-runtime-javadoc-scribe/src/main/java/com/github/therapi/runtimejavadoc/internal/JavadocAnnotationProcessor.java
+++ b/therapi-runtime-javadoc-scribe/src/main/java/com/github/therapi/runtimejavadoc/internal/JavadocAnnotationProcessor.java
@@ -1,13 +1,8 @@
 package com.github.therapi.runtimejavadoc.internal;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Predicate;
+import com.eclipsesource.json.JsonObject;
+import com.github.therapi.runtimejavadoc.RetainJavadoc;
+
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.SourceVersion;
@@ -18,9 +13,12 @@ import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
-
-import com.eclipsesource.json.JsonObject;
-import com.github.therapi.runtimejavadoc.RetainJavadoc;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.javadocResourceSuffix;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -28,8 +26,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class JavadocAnnotationProcessor extends AbstractProcessor {
 
     private static final String PACKAGES_OPTION = "javadoc.packages";
-
-    private static final Predicate<Element> ALL_PACKAGES = e -> true;
 
     private JsonJavadocBuilder jsonJavadocBuilder;
 
@@ -41,15 +37,15 @@ public class JavadocAnnotationProcessor extends AbstractProcessor {
         final String packagesOption = options.get(PACKAGES_OPTION);
 
         // Retain Javadoc for classes that match this predicate
-        final Predicate<Element> packageFilter =
-                packagesOption == null ? ALL_PACKAGES : new PackageFilter(packagesOption);
+        final PackageFilter packageFilter =
+                packagesOption == null ? new PackageFilter() : new PackageFilter(packagesOption);
 
         // Make sure each element only gets processed once.
         final Set<Element> alreadyProcessed = new HashSet<>();
 
         // If retaining Javadoc for all packages, the @RetainJavadoc annotation is redundant.
         // Otherwise, make sure annotated classes have their Javadoc retained regardless of package.
-        if (packageFilter != ALL_PACKAGES) {
+        if (!packageFilter.allowAllPackages()) {
             for (TypeElement annotation : annotations) {
                 if (isRetainJavadocAnnotation(annotation)) {
                     for (Element e : roundEnvironment.getElementsAnnotatedWith(annotation)) {
@@ -95,10 +91,9 @@ public class JavadocAnnotationProcessor extends AbstractProcessor {
             return;
         }
         TypeElement classElement = (TypeElement) element;
-        Optional<JsonObject> maybeClassJsonDoc = jsonJavadocBuilder.getClassJavadocAsJson(classElement);
-        if (maybeClassJsonDoc.isPresent()) {
-            JsonObject classJsonDoc = maybeClassJsonDoc.get();
-            outputJsonDoc(classElement, classJsonDoc);
+        JsonObject maybeClassJsonDoc = jsonJavadocBuilder.getClassJavadocAsJson(classElement);
+        if (maybeClassJsonDoc != null) {
+            outputJsonDoc(classElement, maybeClassJsonDoc);
         }
     }
 

--- a/therapi-runtime-javadoc-scribe/src/main/java/com/github/therapi/runtimejavadoc/internal/JsonJavadocBuilder.java
+++ b/therapi-runtime-javadoc-scribe/src/main/java/com/github/therapi/runtimejavadoc/internal/JsonJavadocBuilder.java
@@ -1,24 +1,23 @@
 package com.github.therapi.runtimejavadoc.internal;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Collector;
-import java.util.stream.Collectors;
+import com.eclipsesource.json.Json;
+import com.eclipsesource.json.JsonArray;
+import com.eclipsesource.json.JsonObject;
+
+import javax.annotation.Nullable;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
-
-import com.eclipsesource.json.Json;
-import com.eclipsesource.json.JsonArray;
-import com.eclipsesource.json.JsonObject;
-import com.eclipsesource.json.JsonValue;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.elementDocFieldName;
 import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.elementNameFieldName;
@@ -26,41 +25,45 @@ import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.en
 import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.fieldsFieldName;
 import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.methodsFieldName;
 import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.paramTypesFieldName;
+import static javax.lang.model.element.ElementKind.ENUM_CONSTANT;
+import static javax.lang.model.element.ElementKind.FIELD;
+import static javax.lang.model.element.ElementKind.METHOD;
 
 class JsonJavadocBuilder {
-
-    private static final Collector<JsonValue, JsonArray, JsonArray> JSON_ARRAY_COLLECTOR = Collector.of(JsonArray::new,
-            JsonArray::add, (arr1, arr2) -> {
-                arr2.forEach(arr1::add);
-                return arr1;
-            });
-
+    
     private final ProcessingEnvironment processingEnv;
 
     JsonJavadocBuilder(ProcessingEnvironment processingEnv) {
         this.processingEnv = processingEnv;
     }
 
-    Optional<JsonObject> getClassJavadocAsJson(TypeElement classElement) {
+    @Nullable
+    JsonObject getClassJavadocAsJson(TypeElement classElement) {
         String classDoc = processingEnv.getElementUtils().getDocComment(classElement);
 
         if (isBlank(classDoc)) {
             classDoc = "";
         }
-
-        Map<ElementKind, List<Element>> children = classElement.getEnclosedElements()
-                                                               .stream()
-                                                               .collect(Collectors.groupingBy(Element::getKind));
-        List<Element> enclosedFields = children.getOrDefault(ElementKind.FIELD, Collections.emptyList());
-        List<Element> enclosedEnumConstants = children.getOrDefault(ElementKind.ENUM_CONSTANT, Collections.emptyList());
-        List<Element> enclosedMethods = children.getOrDefault(ElementKind.METHOD, Collections.emptyList());
-
-        JsonArray fieldDocs = getJavadocsAsJson(enclosedFields, this::getFieldJavadocAsJson);
-        JsonArray enumConstantDocs = getJavadocsAsJson(enclosedEnumConstants, this::getFieldJavadocAsJson);
-        JsonArray methodDocs = getJavadocsAsJson(enclosedMethods, this::getMethodJavadocAsJson);
+    
+        Map<ElementKind, List<Element>> children = new HashMap<>();
+        for (Element enclosedElement : classElement.getEnclosedElements()) {
+            if (!children.containsKey(enclosedElement.getKind())) {
+                children.put(enclosedElement.getKind(), new ArrayList<Element>());
+            }
+            children.get(enclosedElement.getKind()).add(enclosedElement);
+        }
+    
+        final List<Element> emptyList = Collections.unmodifiableList(Collections.<Element>emptyList());
+        List<Element> enclosedFields = children.containsKey(FIELD) ? children.get(FIELD) : emptyList;
+        List<Element> enclosedEnumConstants = children.containsKey(ENUM_CONSTANT) ? children.get(ENUM_CONSTANT) : emptyList;
+        List<Element> enclosedMethods = children.containsKey(METHOD) ? children.get(METHOD) : emptyList;
+        
+        JsonArray fieldDocs = getJavadocsAsJson(enclosedFields, new FieldJavadocAsJson());
+        JsonArray enumConstantDocs = getJavadocsAsJson(enclosedEnumConstants, new FieldJavadocAsJson());
+        JsonArray methodDocs = getJavadocsAsJson(enclosedMethods, new MethodJavadocAsJson());
 
         if (isBlank(classDoc) && fieldDocs.isEmpty() && enumConstantDocs.isEmpty() && methodDocs.isEmpty()) {
-            return Optional.empty();
+            return null;
         }
 
         JsonObject json = new JsonObject();
@@ -68,54 +71,66 @@ class JsonJavadocBuilder {
         json.add(fieldsFieldName(), fieldDocs);
         json.add(enumConstantsFieldName(), enumConstantDocs);
         json.add(methodsFieldName(), methodDocs);
-        return Optional.of(json);
+        return json;
     }
 
-    private static JsonArray getJavadocsAsJson(List<Element> elements,
-            Function<Element, Optional<JsonObject>> createDoc) {
-        return elements.stream()
-                       .map(createDoc)
-                       .filter(Optional::isPresent)
-                       .map(Optional::get)
-                       .collect(JSON_ARRAY_COLLECTOR);
-    }
-
-    private Optional<JsonObject> getFieldJavadocAsJson(Element field) {
-        String javadoc = processingEnv.getElementUtils().getDocComment(field);
-        if (isBlank(javadoc)) {
-            return Optional.empty();
+    private static JsonArray getJavadocsAsJson(List<Element> elements, ElementToJsonFunction createDoc) {
+        JsonArray jsonArray = new JsonArray();
+        for (Element e : elements) {
+            JsonObject eMapped = createDoc.apply(e);
+            if (eMapped != null) {
+                jsonArray.add(eMapped);
+            }
         }
-
-        JsonObject jsonDoc = new JsonObject();
-        jsonDoc.add(elementNameFieldName(), field.getSimpleName().toString());
-        jsonDoc.add(elementDocFieldName(), javadoc);
-        return Optional.of(jsonDoc);
+        return jsonArray;
     }
 
-    private Optional<JsonObject> getMethodJavadocAsJson(Element method) {
-        assert method instanceof ExecutableElement;
-
-        String methodJavadoc = processingEnv.getElementUtils().getDocComment(method);
-        if (isBlank(methodJavadoc)) {
-            return Optional.empty();
+    private interface ElementToJsonFunction {
+        @Nullable JsonObject apply(Element e);
+    }
+    
+    private class FieldJavadocAsJson implements ElementToJsonFunction {
+        @Override @Nullable
+        public JsonObject apply(Element field) {
+            String javadoc = processingEnv.getElementUtils().getDocComment(field);
+            if (isBlank(javadoc)) {
+                return null;
+            }
+            
+            JsonObject jsonDoc = new JsonObject();
+            jsonDoc.add(elementNameFieldName(), field.getSimpleName().toString());
+            jsonDoc.add(elementDocFieldName(), javadoc);
+            return jsonDoc;
         }
-
-        JsonObject jsonDoc = new JsonObject();
-        jsonDoc.add(elementNameFieldName(), method.getSimpleName().toString());
-        jsonDoc.add(paramTypesFieldName(), getParamErasures((ExecutableElement) method));
-        jsonDoc.add(elementDocFieldName(), methodJavadoc);
-        return Optional.of(jsonDoc);
+    }
+    
+    private class MethodJavadocAsJson implements ElementToJsonFunction {
+        @Override @Nullable
+        public JsonObject apply(Element method) {
+            assert method instanceof ExecutableElement;
+    
+            String methodJavadoc = processingEnv.getElementUtils().getDocComment(method);
+            if (isBlank(methodJavadoc)) {
+                return null;
+            }
+    
+            JsonObject jsonDoc = new JsonObject();
+            jsonDoc.add(elementNameFieldName(), method.getSimpleName().toString());
+            jsonDoc.add(paramTypesFieldName(), getParamErasures((ExecutableElement) method));
+            jsonDoc.add(elementDocFieldName(), methodJavadoc);
+            return jsonDoc;
+        }
     }
 
     private JsonArray getParamErasures(ExecutableElement executableElement) {
         Types typeUtils = processingEnv.getTypeUtils();
-        return executableElement.getParameters()
-                                .stream()
-                                .map(Element::asType)
-                                .map(typeUtils::erasure)
-                                .map(TypeMirror::toString)
-                                .map(Json::value)
-                                .collect(JSON_ARRAY_COLLECTOR);
+        
+        final JsonArray jsonValues = new JsonArray();
+        for (VariableElement parameter : executableElement.getParameters()) {
+            TypeMirror erasure = typeUtils.erasure(parameter.asType());
+            jsonValues.add(Json.value(erasure.toString()));
+        }
+        return jsonValues;
     }
 
     private static boolean isBlank(String s) {

--- a/therapi-runtime-javadoc-scribe/src/main/java/com/github/therapi/runtimejavadoc/internal/PackageFilter.java
+++ b/therapi-runtime-javadoc-scribe/src/main/java/com/github/therapi/runtimejavadoc/internal/PackageFilter.java
@@ -1,18 +1,21 @@
 package com.github.therapi.runtimejavadoc.internal;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.function.Predicate;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.QualifiedNameable;
+import java.util.HashSet;
+import java.util.Set;
 
-class PackageFilter implements Predicate<Element> {
+class PackageFilter {
 
     private final Set<String> rootPackages = new HashSet<>();
     private final Set<String> packages = new HashSet<>();
     private final Set<String> negatives = new HashSet<>();
-
+    
+    PackageFilter() {
+        // leaves the package white-list empty, which implies it can be ignore
+    }
+    
     PackageFilter(String commaDelimitedPackages) {
         for (String pkg : commaDelimitedPackages.split(",")) {
             pkg = pkg.trim();
@@ -23,7 +26,6 @@ class PackageFilter implements Predicate<Element> {
         packages.addAll(rootPackages);
     }
 
-    @Override
     public boolean test(Element element) {
         final String elementPackage = getPackage(element);
 
@@ -31,7 +33,7 @@ class PackageFilter implements Predicate<Element> {
             return false;
         }
 
-        if (packages.contains(elementPackage)) {
+        if (packages.isEmpty() || packages.contains(elementPackage)) {
             return true;
         }
 
@@ -55,5 +57,9 @@ class PackageFilter implements Predicate<Element> {
             }
         }
         return ((QualifiedNameable) e).getQualifiedName().toString();
+    }
+    
+    boolean allowAllPackages() {
+        return packages.isEmpty();
     }
 }

--- a/therapi-runtime-javadoc-scribe/src/test/java/com/github/therapi/runtimejavadoc/CompilationClassLoader.java
+++ b/therapi-runtime-javadoc-scribe/src/test/java/com/github/therapi/runtimejavadoc/CompilationClassLoader.java
@@ -41,7 +41,7 @@ public class CompilationClassLoader extends URLClassLoader {
 
     @Override
     public URL findResource(String name) {
-        JavaFileObject generatedResource = compilation.generatedFile(CLASS_OUTPUT, name).orElse(null);
+        final JavaFileObject generatedResource = compilation.generatedFile(CLASS_OUTPUT, name).orElse(null);
         if (generatedResource == null) {
             return super.findResource(name);
         }

--- a/therapi-runtime-javadoc-scribe/src/test/java/com/github/therapi/runtimejavadoc/JavadocAnnotationProcessorTest.java
+++ b/therapi-runtime-javadoc-scribe/src/test/java/com/github/therapi/runtimejavadoc/JavadocAnnotationProcessorTest.java
@@ -1,22 +1,21 @@
 package com.github.therapi.runtimejavadoc;
 
+import com.github.therapi.runtimejavadoc.internal.JavadocAnnotationProcessor;
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import org.junit.Test;
+
+import javax.tools.JavaFileObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import javax.tools.JavaFileObject;
-
-import org.junit.Test;
-
-import com.github.therapi.runtimejavadoc.internal.JavadocAnnotationProcessor;
-import com.google.testing.compile.Compilation;
-import com.google.testing.compile.JavaFileObjects;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class JavadocAnnotationProcessorTest {
 
@@ -160,10 +159,10 @@ public class JavadocAnnotationProcessorTest {
     }
 
     private static void assertFieldDocMatches(Field field, String expectedDoc) {
-        Optional<FieldJavadoc> fieldJavadoc = RuntimeJavadoc.getJavadoc(field);
-        assertTrue(fieldJavadoc.isPresent());
-        assertEquals(field.getName(), fieldJavadoc.get().getName());
-        assertEquals(expectedDoc, fieldJavadoc.get().getComment().toString());
+        FieldJavadoc fieldJavadoc = RuntimeJavadoc.getJavadoc(field);
+        assertNotNull(fieldJavadoc);
+        assertEquals(field.getName(), fieldJavadoc.getName());
+        assertEquals(expectedDoc, fieldJavadoc.getComment().toString());
     }
 
     private static void assertEnumConstantMatches(Enum enumConstant, String expectedDoc) {
@@ -220,21 +219,25 @@ public class JavadocAnnotationProcessorTest {
     }
 
     private static ClassJavadoc expectJavadoc(Class<?> c) {
-        return RuntimeJavadoc.getJavadoc(c)
-                .orElseThrow(() -> new AssertionError("Missing Javadoc for " + c));
+        return assertNonNull(RuntimeJavadoc.getJavadoc(c), "Missing Javadoc for " + c);
     }
 
     private static MethodJavadoc expectJavadoc(Method m) {
-        return RuntimeJavadoc.getJavadoc(m)
-                .orElseThrow(() -> new AssertionError("Missing Javadoc for " + m));
+        return assertNonNull(RuntimeJavadoc.getJavadoc(m), "Missing Javadoc for " + m);
     }
 
     private static FieldJavadoc expectJavadoc(Enum<?> e) {
-        return RuntimeJavadoc.getJavadoc(e)
-                .orElseThrow(() -> new AssertionError("Missing Javadoc for " + e));
+        return assertNonNull(RuntimeJavadoc.getJavadoc(e), "Missing Javadoc for " + e);
     }
 
     private static void expectNoJavadoc(Class<?> c) {
-        assertEquals(Optional.empty(), RuntimeJavadoc.getJavadoc(c));
+        assertNull(RuntimeJavadoc.getJavadoc(c));
+    }
+    
+    private static <T> T assertNonNull(T value, String msg) {
+        if (value == null) {
+            throw new AssertionError(msg);
+        }
+        return value;
     }
 }

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/MethodJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/MethodJavadoc.java
@@ -1,9 +1,8 @@
 package com.github.therapi.runtimejavadoc;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.unmodifiableDefensiveCopy;
 
@@ -39,9 +38,10 @@ public class MethodJavadoc {
         if (!method.getName().equals(name)) {
             return false;
         }
-        List<String> methodParamsTypes = Arrays.stream(method.getParameterTypes())
-                                               .map(Class::getCanonicalName)
-                                               .collect(Collectors.toList());
+        List<String> methodParamsTypes = new ArrayList<>();
+        for (Class<?> aClass : method.getParameterTypes()) {
+            methodParamsTypes.add(aClass.getCanonicalName());
+        }
         return methodParamsTypes.equals(paramTypes);
     }
 

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/JsonJavadocReader.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/JsonJavadocReader.java
@@ -3,7 +3,6 @@ package com.github.therapi.runtimejavadoc.internal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
@@ -12,6 +11,8 @@ import com.github.therapi.runtimejavadoc.ClassJavadoc;
 import com.github.therapi.runtimejavadoc.FieldJavadoc;
 import com.github.therapi.runtimejavadoc.MethodJavadoc;
 import com.github.therapi.runtimejavadoc.internal.parser.JavadocParser;
+
+import javax.annotation.Nullable;
 
 import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.elementDocFieldName;
 import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.elementNameFieldName;
@@ -22,15 +23,14 @@ import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.pa
 
 public class JsonJavadocReader {
 
-    public static Optional<ClassJavadoc> readClassJavadoc(String qualifiedClassName, JsonObject json) {
+    @Nullable
+    public static ClassJavadoc readClassJavadoc(String qualifiedClassName, JsonObject json) {
         String className = qualifiedClassName.replace("$", ".");
         List<FieldJavadoc> fields = readFieldDocs(json.get(fieldsFieldName()));
         List<FieldJavadoc> enumConstants = readFieldDocs(json.get(enumConstantsFieldName()));
         List<MethodJavadoc> methods = readMethodDocs(json.get(methodsFieldName()));
         String classJavadocString = json.getString(elementDocFieldName(), null);
-        ClassJavadoc classJavadoc = JavadocParser.parseClassJavadoc(className, classJavadocString, fields,
-                enumConstants, methods);
-        return Optional.of(classJavadoc);
+        return JavadocParser.parseClassJavadoc(className, classJavadocString, fields, enumConstants, methods);
     }
 
     private static List<FieldJavadoc> readFieldDocs(JsonValue fieldsValue) {

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/JavadocParser.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/JavadocParser.java
@@ -10,6 +10,8 @@ import com.github.therapi.runtimejavadoc.FieldJavadoc;
 import com.github.therapi.runtimejavadoc.MethodJavadoc;
 import com.github.therapi.runtimejavadoc.OtherJavadoc;
 import com.github.therapi.runtimejavadoc.ParamJavadoc;
+import com.github.therapi.runtimejavadoc.SeeAlsoJavadoc;
+import com.github.therapi.runtimejavadoc.ThrowsJavadoc;
 
 public class JavadocParser {
 
@@ -28,7 +30,7 @@ public class JavadocParser {
         }
 
         return new ClassJavadoc(className, CommentParser.parse(parsed.getDescription()), fields, enumConstants, methods,
-                otherDocs, new ArrayList<>());
+                otherDocs, new ArrayList<SeeAlsoJavadoc>());
     }
 
     public static FieldJavadoc parseFieldJavadoc(String fieldName, String javadoc) {
@@ -39,7 +41,7 @@ public class JavadocParser {
             otherDocs.add(new OtherJavadoc(t.name, CommentParser.parse(t.value)));
         }
 
-        return new FieldJavadoc(fieldName, CommentParser.parse(parsed.getDescription()), otherDocs, new ArrayList<>());
+        return new FieldJavadoc(fieldName, CommentParser.parse(parsed.getDescription()), otherDocs, new ArrayList<SeeAlsoJavadoc>());
     }
 
     public static MethodJavadoc parseMethodJavadoc(String methodName, List<String> paramTypes, String javadoc) {
@@ -65,7 +67,7 @@ public class JavadocParser {
         }
 
         return new MethodJavadoc(methodName, paramTypes, CommentParser.parse(parsed.getDescription()), paramDocs,
-                new ArrayList<>(), otherDocs, returns, new ArrayList<>());
+                new ArrayList<ThrowsJavadoc>(), otherDocs, returns, new ArrayList<SeeAlsoJavadoc>());
     }
 
     private static ParsedJavadoc parse(String javadoc) {

--- a/therapi-runtime-javadoc/src/test/java/com/github/therapi/runtimejavadoc/Example.java
+++ b/therapi-runtime-javadoc/src/test/java/com/github/therapi/runtimejavadoc/Example.java
@@ -7,7 +7,7 @@ public class Example {
     private static final CommentFormatter formatter = new CommentFormatter();
 
     public static void printJavadoc(String fullyQualifiedClassName) throws IOException {
-        ClassJavadoc classDoc = RuntimeJavadoc.getJavadoc(fullyQualifiedClassName).orElse(null);
+        ClassJavadoc classDoc = RuntimeJavadoc.getJavadoc(fullyQualifiedClassName);
         if (classDoc == null) {
             System.out.println("no documentation for " + fullyQualifiedClassName);
             return;


### PR DESCRIPTION
Backported project to Java 7 for https://github.com/dnault/therapi-runtime-javadoc/issues/22 (but tests still run in Java 8 due to Google Compiler dependency, couldn't solve that one). It now works with the widely accepted and supported [@Nullable and @NonNull](https://medium.com/square-corner-blog/rolling-out-nullable-42dd823fbd89) annotations by findbugs (used in Guava as well).

I hope you can use this (or a variation of this), but please let me know if this is a path you are willing to take. If not, I intend to (re)publish this Java 7 fork in maven central (with a different package of course) if the poc with my own library is successful.

Looking forward to hear your thoughts.