### PR TITLE
#41 Constructor javadoc is missing when there is no class level…

### DIFF
--- a/therapi-runtime-javadoc-scribe/src/main/java/com/github/therapi/runtimejavadoc/internal/JsonJavadocBuilder.java
+++ b/therapi-runtime-javadoc-scribe/src/main/java/com/github/therapi/runtimejavadoc/internal/JsonJavadocBuilder.java
@@ -65,7 +65,7 @@ class JsonJavadocBuilder {
         JsonArray methodDocs = getJavadocsAsJson(enclosedMethods, new MethodJavadocAsJson());
         JsonArray constructorDocs = getJavadocsAsJson(encolsedConstructors, new MethodJavadocAsJson());
 
-        if (isBlank(classDoc) && fieldDocs.isEmpty() && enumConstantDocs.isEmpty() && methodDocs.isEmpty() && constructorDocs.isArray()) {
+        if (isBlank(classDoc) && fieldDocs.isEmpty() && enumConstantDocs.isEmpty() && methodDocs.isEmpty() && constructorDocs.isEmpty()) {
             return null;
         }
 


### PR DESCRIPTION
Resolves #41.  Fix so that javadocs for constructors appear when there is no docs anywhere else