### PR TITLE
Comment visitor pattern

### DIFF
--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/Comment.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/Comment.java
@@ -40,6 +40,12 @@ public class Comment implements Iterable<CommentElement> {
         return elements.iterator();
     }
 
+    public void visit( CommentVisitor visitor ) {
+        for ( CommentElement e : elements ) {
+            e.visit( visitor );
+        }
+    }
+
     @Override
     public String toString() {
         return new CommentFormatter().format(this);

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/CommentElement.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/CommentElement.java
@@ -2,4 +2,5 @@ package com.github.therapi.runtimejavadoc;
 
 
 public abstract class CommentElement {
+    public abstract void visit( CommentVisitor visitor );
 }

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/CommentFormatter.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/CommentFormatter.java
@@ -18,93 +18,9 @@ public class CommentFormatter {
             return "";
         }
 
-        StringBuilder sb = new StringBuilder();
+        ToHtmlStringCommentVisitor visitor = new ToHtmlStringCommentVisitor();
+        comment.visit( visitor );
 
-        for (CommentElement e : comment) {
-            if (e instanceof CommentText) {
-                sb.append(renderText((CommentText) e));
-
-            } else if (e instanceof InlineLink) {
-                sb.append(renderLink((InlineLink) e));
-    
-            } else if (e instanceof InlineValue) {
-                sb.append(renderValue((InlineValue) e));
-    
-            } else if (e instanceof InlineTag) {
-                sb.append(renderTag((InlineTag) e));
-
-            } else {
-                sb.append(renderUnrecognized(e));
-            }
-        }
-
-        return sb.toString();
-    }
-
-    protected String renderText(CommentText text) {
-        return text.getValue();
-    }
-    
-    protected String renderLink(InlineLink e) {
-        return "{@link " + e.getLink() + "}";
-    }
-    
-    protected String renderValue(InlineValue e) {
-		return e.getValue().getReferencedMemberName() == null ? "{@value}" : "{@value " + e.getValue() + "}";
-    }
-
-    protected String renderUnrecognized(CommentElement e) {
-        return e.toString();
-    }
-
-    protected String renderTag(InlineTag e) {
-        switch (e.getName()) {
-            case "code":
-                return renderCode(e);
-            case "literal":
-                return renderLiteral(e);
-            default:
-                return renderUnrecognizedTag(e);
-        }
-    }
-
-    protected String renderCode(InlineTag e) {
-        return "<code>" + escapeHtml(e.getValue()) + "</code>";
-    }
-
-    protected String renderLiteral(InlineTag e) {
-        return escapeHtml(e.getValue());
-    }
-
-    protected String renderUnrecognizedTag(InlineTag e) {
-        return "{@" + e.getName() + " " + e.getValue() + "}";
-    }
-
-    /**
-     * Escapes the HTML special characters: {@code " & < >}
-     *
-     * @param value The value to escape
-     * @return the input value with any instances of HTML special characters converted to character entities.
-     */
-    protected String escapeHtml(String value) {
-        StringBuilder escaped = new StringBuilder();
-
-        for (int i = 0, len = value.length(); i < len; i++) {
-            final char c = value.charAt(i);
-
-            if (c == '"') {
-                escaped.append("&quot;");
-            } else if (c == '&') {
-                escaped.append("&amp;");
-            } else if (c == '<') {
-                escaped.append("&lt;");
-            } else if (c == '>') {
-                escaped.append("&gt;");
-            } else {
-                escaped.append(c);
-            }
-        }
-
-        return escaped.toString();
+        return visitor.build();
     }
 }

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/CommentText.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/CommentText.java
@@ -13,6 +13,10 @@ public class CommentText extends CommentElement {
         return value;
     }
 
+    public void visit( CommentVisitor visitor ) {
+        visitor.commentText( value );
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/CommentVisitor.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/CommentVisitor.java
@@ -1,0 +1,12 @@
+package com.github.therapi.runtimejavadoc;
+
+
+public interface CommentVisitor {
+    public void commentText( String value );
+
+    public void inlineLink( Link link );
+
+    public void inlineTag( String name, String value );
+
+    public void inlineValue( Value value );
+}

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/InlineLink.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/InlineLink.java
@@ -13,6 +13,10 @@ public class InlineLink extends CommentElement {
         return link;
     }
 
+    public void visit( CommentVisitor visitor ) {
+        visitor.inlineLink( link );
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/InlineTag.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/InlineTag.java
@@ -19,6 +19,10 @@ public class InlineTag extends CommentElement {
         return value;
     }
 
+    public void visit( CommentVisitor visitor ) {
+        visitor.inlineTag( name, value );
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/InlineValue.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/InlineValue.java
@@ -13,6 +13,10 @@ public class InlineValue extends CommentElement {
         return value;
     }
 
+    public void visit( CommentVisitor visitor ) {
+        visitor.inlineValue( value );
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/ToHtmlStringCommentVisitor.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/ToHtmlStringCommentVisitor.java
@@ -1,0 +1,75 @@
+package com.github.therapi.runtimejavadoc;
+
+
+class ToHtmlStringCommentVisitor implements CommentVisitor {
+    public StringBuilder buf = new StringBuilder();
+
+    public void commentText( String value ) {
+        buf.append( value );
+    }
+
+    public void inlineLink( Link link ) {
+        buf.append("{@link ");
+        buf.append(link);
+        buf.append("}");
+    }
+
+    public void inlineTag( String name, String value ) {
+        if ("code".equals(name)) {
+            buf.append( "<code>" );
+            buf.append( escapeHtml( value ) );
+            buf.append( "</code>" );
+        } else if ("literal".equals(name)) {
+            buf.append(escapeHtml(value));
+        } else {
+            buf.append("{@");
+            buf.append(name);
+            buf.append(" ");
+            buf.append(value);
+            buf.append("}");
+        }
+    }
+
+    public void inlineValue( Value value ) {
+        if (value.getReferencedMemberName() == null) {
+            buf.append("{@value}");
+        } else {
+            buf.append("{@value ");
+            buf.append(value);
+            buf.append("}");
+        }
+    }
+
+    public String build() {
+        return buf.toString();
+    }
+
+    /**
+     * Escapes the HTML special characters: {@code " & < >}
+     *
+     * @param value The value to escape
+     * @return the input value with any instances of HTML special characters converted to character entities.
+     */
+    protected static String escapeHtml(String value) {
+        StringBuilder escaped = new StringBuilder();
+
+        for (int i = 0, len = value.length(); i < len; i++) {
+            final char c = value.charAt(i);
+
+            if (c == '"') {
+                escaped.append("&quot;");
+            } else if (c == '&') {
+                escaped.append("&amp;");
+            } else if (c == '<') {
+                escaped.append("&lt;");
+            } else if (c == '>') {
+                escaped.append("&gt;");
+            } else {
+                escaped.append(c);
+            }
+        }
+
+        return escaped.toString();
+    }
+
+}

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/ToTextListCommentVisitor.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/ToTextListCommentVisitor.java
@@ -1,0 +1,44 @@
+package com.github.therapi.runtimejavadoc;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+public class ToTextListCommentVisitor implements CommentVisitor {
+    public List<String> lines = new ArrayList<>();
+
+    public void commentText( String value ) {
+        String[] splits = value.split( "\r\n|\n" );
+
+        lines.addAll( Arrays.asList( splits ) );
+    }
+
+    public void inlineLink( Link link ) {
+        appendInlineText( link.toString() );
+    }
+
+    public void inlineTag( String name, String value ) {
+        appendInlineText( value );
+    }
+
+    public void inlineValue( Value value ) {
+        appendInlineText( value.toString() );
+    }
+
+    public List<String> build() {
+        return lines;
+    }
+
+    private void appendInlineText( String txt ) {
+        if (txt == null ) {
+        } else if ( lines.isEmpty() ) {
+            lines.add( txt );
+        } else {
+            int index = lines.size() - 1;
+            String newLine = lines.get( index ) + txt;
+
+            lines.set( index, newLine );
+        }
+    }
+}

--- a/therapi-runtime-javadoc/src/test/java/com/github/therapi/runtimejavadoc/CommentFormatterTest.java
+++ b/therapi-runtime-javadoc/src/test/java/com/github/therapi/runtimejavadoc/CommentFormatterTest.java
@@ -25,7 +25,11 @@ public class CommentFormatterTest {
                 new InlineTag("unrecognized", "foo"),
                 new CommentText(" "),
                 new CommentElement() {
-                    @Override public String toString() {
+                    public void visit( CommentVisitor visitor ) {
+                        visitor.commentText( "unexpected element" );
+                    }
+
+                    public String toString() {
                         return "unexpected element";
                     }
                 },

--- a/therapi-runtime-javadoc/src/test/java/com/github/therapi/runtimejavadoc/ToTextListCommentVisitorTest.java
+++ b/therapi-runtime-javadoc/src/test/java/com/github/therapi/runtimejavadoc/ToTextListCommentVisitorTest.java
@@ -1,0 +1,60 @@
+package com.github.therapi.runtimejavadoc;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class ToTextListCommentVisitorTest {
+    private ToTextListCommentVisitor visitor = new ToTextListCommentVisitor();
+
+    @Test
+    public void commentText() {
+        visitor.commentText(
+            "Excepteur sint occaecat cupidatat non proident,\n" +
+                " sunt in culpa qui officia deserunt mollit\r\n" +
+                " anim id est laborum."
+        );
+
+        List<String> expected = Arrays.asList(
+            "Excepteur sint occaecat cupidatat non proident,",
+                " sunt in culpa qui officia deserunt mollit",
+                " anim id est laborum."
+        );
+
+        assertEquals(expected, visitor.build());
+    }
+
+    @Test
+    public void link() {
+        visitor.inlineLink(new Link(null, "java.lang.String", "toString", Collections.<String>emptyList() ));
+        visitor.inlineLink(new Link(null, "java.lang.String", "toString", Collections.<String>emptyList() ));
+
+        List<String> expected = Arrays.asList( "java.lang.String#toStringjava.lang.String#toString" );
+
+        assertEquals(expected, visitor.build());
+    }
+
+    @Test
+    public void inlineTag() {
+        visitor.inlineTag("foo", "bar");
+
+        List<String> expected = Arrays.asList( "bar" );
+
+        assertEquals(expected, visitor.build());
+    }
+
+    @Test
+    public void inlineValue() {
+        visitor.inlineValue(new Value("java.lang.String","toString"));
+
+        List<String> expected = Arrays.asList( "java.lang.String#toString" );
+
+        assertEquals(expected, visitor.build());
+    }
+
+}


### PR DESCRIPTION
This PR adds the plumbing for the visitor pattern across Comment and CommentElements.  It offers two implementations of the callback interface and replaces the internals of the existing CommentFormatter to use one of the new callbacks.

Because this PR adds more classes around comments, I made the call to move the comment classes and support classes into their own package.  This might not be popular, so I placed the package move into its own commit;  which will make it easier to drop out of the PR.

Resolves #47.