### PR TITLE
Add overridden method javadoc if none exists on declared method

### DIFF
--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/bar/OverridingClassInAnotherPackage.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/bar/OverridingClassInAnotherPackage.java
@@ -1,0 +1,21 @@
+package javasource.bar;
+
+import java.util.List;
+import javasource.foo.DocumentedClass;
+
+
+// I override methods of DocumentedClass with and without their own javadoc
+public class OverridingClassInAnotherPackage extends DocumentedClass {
+
+  /**
+   * Quick frobulate {@code a} by {@code b} using thin frobulation
+   */
+  public int frobulate(String a, int b) {
+    throw new UnsupportedOperationException();
+  }
+
+  // I have no javadoc of my own
+  public int frobulate(String a, List<Integer> b) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/CompetingInterface.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/CompetingInterface.java
@@ -1,0 +1,19 @@
+package javasource.foo;
+
+/**
+ * The {@code Javadoc} from this interface is used for masking
+ *
+ */
+public interface CompetingInterface<T extends Number> {
+    /**
+     * Hoodwink a schmadragon
+     */
+    public boolean hoodwink(String g);
+
+    /**
+     * Fling the vorrdin
+     * @param v
+     * @return
+     */
+    public boolean fling(T v);
+}

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/ComplexImplementation.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/ComplexImplementation.java
@@ -1,0 +1,19 @@
+package javasource.foo;
+
+import javasource.foo.DocumentedInterface;
+
+public class ComplexImplementation implements DocumentedInterface<Integer>, CompetingInterface<Integer> {
+    // I have no javadoc of my own
+    public boolean hoodwink(String i) {
+        throw new UnsupportedOperationException();
+    }
+
+    // I have no javadoc of my own
+    public boolean snaggle(String i) {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean fling(Integer v) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/DocumentedClass.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/DocumentedClass.java
@@ -19,6 +19,11 @@ public class DocumentedClass {
   private int myField;
 
   /**
+   * I'm a field my children can see.
+   */
+  protected int ourField;
+
+  /**
    * I'm a constructor!
    */
   public DocumentedClass() {
@@ -73,11 +78,22 @@ public class DocumentedClass {
   }
 
   /**
+   * I am a simple method
+   */
+  public void simpleMethod() {
+
+  }
+
+  /**
    * Foo {@link Foo#bar(String).}{@value Foo#bar(String).}
    *
    * @see Foo#bar(String).
    */
   public void malformedLinks() {
+  }
+
+  public boolean equals(Object o) {
+    return super.equals(o);
   }
 
   /**

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/DocumentedImplementation.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/DocumentedImplementation.java
@@ -1,0 +1,25 @@
+package javasource.foo;
+
+import javasource.foo.DocumentedInterface;
+
+public class DocumentedImplementation implements DocumentedInterface<Integer> {
+    /**
+     * hoodwink a stranger
+     */
+    public boolean hoodwink(String i) {
+        throw new UnsupportedOperationException();
+    }
+
+    // I have no javadoc of my own
+    public boolean snaggle(String i) {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean fling(Integer v) {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean fling(Object v) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/DocumentedInterface.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/DocumentedInterface.java
@@ -1,0 +1,32 @@
+package javasource.foo;
+
+/**
+ * The {@code Javadoc} from this interface is used for testing
+ *
+ */
+public interface DocumentedInterface<T extends Number> {
+    /**
+     * Hoodwink a kerfluffin
+     *
+     * @param i innocent
+     * @return true if innocent hoodwinked
+     * @throws UnsupportedOperationException if hoodwinking cannot be performed
+     */
+    public boolean hoodwink(String i);
+
+    /**
+     * Snaggle a kerfluffin
+     *
+     * @param i innocent
+     * @return true if innocent hoodwinked
+     * @throws UnsupportedOperationException if hoodwinking cannot be performed
+     */
+    public boolean snaggle(String i);
+
+    /**
+     * Fling the tea
+     * @param v
+     * @return
+     */
+    public boolean fling(T v);
+}

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/GenericClass.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/GenericClass.java
@@ -1,0 +1,28 @@
+package javasource.foo;
+
+/**
+ * The {@code Javadoc} from this class is used for testing generic classes and methods
+ *
+ * @author nobody@example.com
+ * @custom.tag What does {@custom.inline this} mean?
+ */
+public class GenericClass<T> {
+
+    /**
+     * Generic method to do generic things
+     */
+    public T genericMethod(T generic) {
+        return generic;
+    }
+
+    /**
+     * Generic method to do other things
+     */
+    public <U extends Comparable<U>> T separateGeneric(U otherGeneric) {
+        throw new UnsupportedOperationException();
+    }
+
+    public T blankGenericMethod() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/OverridingClass.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/OverridingClass.java
@@ -1,0 +1,34 @@
+package javasource.foo;
+
+import java.util.List;
+import javasource.foo.DocumentedClass;
+
+
+// I override methods of DocumentedClass with and without their own javadoc
+public class OverridingClass extends DocumentedClass {
+
+  /**
+   * Super frobulate {@code a} by {@code b} using extended frobulation
+   *
+   * @see com.github.therapi.runtimejavadoc.DocumentedClass Hey, that's this class!
+   * @see javasource.foo.DocumentedClass#someOtherMethod()
+   * @see "Moomoo boy went straight to Moomoo land. Land of the moomoo's"
+   * @see <a href="http://www.moomoo.land">Moomoo land</a>
+   */
+  public int frobulate(String a, int b) {
+    throw new UnsupportedOperationException();
+  }
+
+  // I have no javadoc of my own
+  public int frobulate(String a, List<Integer> b) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * My very own method
+   *
+   */
+  public void myOwnMethod() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/OverridingClass2Degrees.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/OverridingClass2Degrees.java
@@ -1,0 +1,13 @@
+package javasource.foo;
+
+import java.util.List;
+import javasource.foo.OverridingClass;
+
+
+// I override methods of DocumentedClass with and without their own javadoc
+public class OverridingClass2Degrees extends OverridingClass {
+
+  public void simpleMethod() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/OverridingGenericClass.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/OverridingGenericClass.java
@@ -1,0 +1,14 @@
+package javasource.foo;
+
+public class OverridingGenericClass extends GenericClass<String> {
+
+    // I have no javadoc
+    public String genericMethod(String generic) {
+        return generic;
+    }
+
+    // Even though I may no look like it I override nothing but do partially hide a method
+    public String separateGeneric(Integer otherGeneric) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/VeryComplexImplementation.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/VeryComplexImplementation.java
@@ -1,0 +1,14 @@
+package javasource.foo;
+
+import javasource.foo.DocumentedInterface;
+
+public class VeryComplexImplementation extends DocumentedImplementation implements CompetingInterface<Integer> {
+    // I have no javadoc of my own
+    public boolean hoodwink(String i) {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean fling(Integer v) {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
This adds javadoc from the overridden method in super class or interfaces if none is present on the declared method during the annotation processing phase.
When a class is extended and/or multiple interfaces are implemented with the same signature priority returned by Types.directSuperTypes as is done by the javadoc command line tool
The super elements are depth first searched for overrding method javadoc and the first found javadoc is returned.
Note this implementation does not require @ Override to be present on the method.

Note that since this performs the javadoc copying during the annotation processing there is potentially duplication of javadoc. Also this does not support the partial inheritance of javadoc parts as described at https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/javadoc.html#inheritingcomments.

I chose this method to try and limit the edge cases that pop up with determining overrides in the reflection API especially when it comes to generics, type erasure, and bridge methods. That being said an implementation of finding the overriding method at runtime could be done as a complement to this or a wholesale replacement depending on the value of minimizing any tree traversal at runtime.

Let me know if you want any changes, see any holes or think the runtime approach is better.

This did not cover the case of adding the javadoc from protected fields or parsing @ inheritdoc as I think these are a separate concern.

Note that when you generate javadoc for the VeryComplexImplementation it actually does not follow the algorithm provided in the link. It actually performs recursive search on the superclass first resulting in inheriting the javadoc for the fling method from DocumentedInterface rather than CompetingInterface as would be expected if the algorithm ran as described. So likely the order priority is something that changes with java versions unfortunately

Closes #61 