### PR TITLE
Resolves #61. Inherit missing javadoc components from overridden methods

### DIFF
--- a/therapi-runtime-javadoc-scribe/src/test/java/com/github/therapi/runtimejavadoc/JavadocAnnotationProcessorTest.java
+++ b/therapi-runtime-javadoc-scribe/src/test/java/com/github/therapi/runtimejavadoc/JavadocAnnotationProcessorTest.java
@@ -3,6 +3,8 @@ package com.github.therapi.runtimejavadoc;
 import com.github.therapi.runtimejavadoc.scribe.JavadocAnnotationProcessor;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
+import java.util.Arrays;
+import static org.junit.Assert.assertFalse;
 import org.junit.Test;
 
 import javax.tools.JavaFileObject;
@@ -26,6 +28,14 @@ public class JavadocAnnotationProcessorTest {
     private static final String DOCUMENTED_CLASS = "javasource.foo.DocumentedClass";
     private static final String DOCUMENTED_ENUM = "javasource.foo.DocumentedEnum";
     private static final String COMPLEX_ENUM = "javasource.foo.ComplexEnum";
+    private static final String OVERRIDING_CLASS_IN_ANOTHER_PACKAGE = "javasource.bar.OverridingClassInAnotherPackage";
+    private static final String OVERRIDING_CLASS = "javasource.foo.OverridingClass";
+    private static final String OVERRIDING_CLASS_2_DEGREES = "javasource.foo.OverridingClass2Degrees";
+    private static final String OTHER_INTERFACE = "javasource.foo.OtherInterface";
+    private static final String DOCUMENTED_INTERFACE = "javasource.foo.DocumentedInterface";
+    private static final String DOCUMENTED_IMPLEMENTATION = "javasource.foo.DocumentedImplementation";
+    private static final String COMPLEX_IMPLEMENTATION = "javasource.foo.ComplexImplementation";
+    private static final String VERY_COMPLEX_IMPLEMENTATION = "javasource.foo.VeryComplexImplementation";
     private static final String ANOTHER_DOCUMENTED_CLASS = "javasource.bar.AnotherDocumentedClass";
     private static final String ANNOTATED_WITH_RETAIN_JAVADOC = "javasource.bar.YetAnotherDocumentedClass";
     private static final String UNDOCUMENTED = "javasource.bar.UndocumentedClass";
@@ -41,6 +51,14 @@ public class JavadocAnnotationProcessorTest {
                 "javasource/foo/DocumentedClass.java",
                 "javasource/foo/DocumentedEnum.java",
                 "javasource/foo/ComplexEnum.java",
+                "javasource/foo/OverridingClass.java",
+                "javasource/foo/OverridingClass2Degrees.java",
+                "javasource/foo/DocumentedInterface.java",
+                "javasource/foo/DocumentedImplementation.java",
+                "javasource/foo/ComplexImplementation.java",
+                "javasource/foo/VeryComplexImplementation.java",
+                "javasource/foo/OtherInterface.java",
+                "javasource/bar/OverridingClassInAnotherPackage.java",
                 "javasource/bar/AnotherDocumentedClass.java",
                 "javasource/bar/YetAnotherDocumentedClass.java",
                 "javasource/bar/UndocumentedClass.java",
@@ -77,6 +95,17 @@ public class JavadocAnnotationProcessorTest {
             Class<?> c = classLoader.loadClass(DOCUMENTED_CLASS);
             ClassJavadoc classJavadoc = expectJavadoc(c);
             assertEquals(DOCUMENTED_CLASS, classJavadoc.getName());
+        }
+    }
+
+    @Test
+    public void methodsFullyPopulatedByDefault() throws Exception {
+        try (CompilationClassLoader classLoader = compile(null)) {
+            Class<?> c = classLoader.loadClass(OVERRIDING_CLASS);
+            ClassJavadoc classJavadoc = expectJavadoc(c);
+
+            Method m = c.getMethod("frobulate", String.class, List.class);
+            assertFalse(classJavadoc.findMatchingMethod(m).isEmpty());
         }
     }
 
@@ -231,6 +260,228 @@ public class JavadocAnnotationProcessorTest {
 
             assertMethodMatches(m1, "Frobulate <code>a</code> by <code>b</code>");
             assertMethodMatches(m2, "Frobulate <code>a</code> by multiple oopsifizzle constants");
+
+            Method m3 = c.getDeclaredMethod("equals", Object.class);
+
+            // javadoc tools do not inherit javadoc from Object
+            expectNoJavadoc(m3);
+        }
+    }
+
+    @Test
+    public void methodsMatchDespiteExtendingFromAnotherPackage() throws Exception {
+        try (CompilationClassLoader classLoader = compile(null)) {
+            Class<?> c = classLoader.loadClass(OVERRIDING_CLASS_IN_ANOTHER_PACKAGE);
+
+            final String methodName = "frobulate";
+            Method m1 = c.getDeclaredMethod(methodName, String.class, int.class);
+            Method m2 = c.getDeclaredMethod(methodName, String.class, List.class);
+
+            assertMethodDescriptionMatches(m1, "Quick frobulate <code>a</code> by <code>b</code> using thin frobulation");
+            assertMethodDescriptionMatches(m2, "Frobulate <code>a</code> by multiple oopsifizzle constants");
+        }
+    }
+
+    @Test
+    public void methodsMatchWithExtendedClass() throws Exception {
+        try (CompilationClassLoader classLoader = compile(null)) {
+            Class<?> c = classLoader.loadClass(OVERRIDING_CLASS);
+
+            final String methodName = "frobulate";
+            Method m1 = c.getDeclaredMethod(methodName, String.class, int.class);
+
+            MethodJavadoc methodJavadoc1 = expectJavadoc(m1);
+            assertEquals(m1.getName(), methodJavadoc1.getName());
+
+            String actualDesc = formatter.format(methodJavadoc1.getComment());
+            assertEquals("Super frobulate <code>a</code> by <code>b</code> using extended frobulation", actualDesc);
+            assertEquals(2, methodJavadoc1.getParams().size());
+            assertFalse(methodJavadoc1.getReturns().getElements().isEmpty());
+            assertFalse(methodJavadoc1.getThrows().isEmpty());
+
+            Method m2 = c.getDeclaredMethod(methodName, String.class, List.class);
+            assertMethodDescriptionMatches(m2, "Frobulate <code>a</code> by multiple oopsifizzle constants");
+        }
+    }
+
+    @Test
+    public void methodsMatchWithExtendedClass2Degrees() throws Exception {
+        try (CompilationClassLoader classLoader = compile(null)) {
+            Class<?> c = classLoader.loadClass(OVERRIDING_CLASS_2_DEGREES);
+
+            final String methodName = "skipMethod";
+            Method m1 = c.getDeclaredMethod(methodName);
+
+            MethodJavadoc methodJavadoc1 = expectJavadoc(m1);
+            assertEquals(m1.getName(), methodJavadoc1.getName());
+
+            String actualDesc = formatter.format(methodJavadoc1.getComment());
+            assertEquals("I am also a simple method", actualDesc);
+            assertFalse(methodJavadoc1.getThrows().isEmpty());
+        }
+    }
+
+    @Test
+    public void genericMethodsMatchWithExtendedClass() throws Exception {
+        try (CompilationClassLoader classLoader = compile(null)) {
+            Class<?> c = classLoader.loadClass(OVERRIDING_CLASS);
+
+            final String methodName1 = "genericMethod";
+            Method m1 = c.getDeclaredMethod(methodName1, String.class);
+
+            assertMethodDescriptionMatches(m1, "Generic method to do generic things");
+
+            final String methodName2 = "separateGeneric";
+            Method m2 = c.getDeclaredMethod(methodName2, Integer.class);
+
+            expectNoJavadoc(m2);
+        }
+    }
+
+    @Test
+    public void genericMethodsMatchWithClass() throws Exception {
+        try (CompilationClassLoader classLoader = compile(null)) {
+            Class<?> c = classLoader.loadClass(DOCUMENTED_CLASS);
+
+            final String methodName1 = "genericMethod";
+            Method m1 = c.getDeclaredMethod(methodName1, Object.class);
+
+            assertMethodDescriptionMatches(m1, "Generic method to do generic things");
+
+            final String methodName2 = "separateGeneric";
+            Method m2 = c.getDeclaredMethod(methodName2, Comparable.class);
+
+            assertMethodDescriptionMatches(m2, "Generic method to do other things");
+        }
+    }
+
+    @Test
+    public void methodsMatchWithImplementation() throws Exception {
+        try (CompilationClassLoader classLoader = compile(null)) {
+            Class<?> c = classLoader.loadClass(DOCUMENTED_IMPLEMENTATION);
+
+            final String methodName = "hoodwink";
+            Method m1 = c.getDeclaredMethod(methodName, String.class);
+
+            MethodJavadoc methodJavadoc1 = expectJavadoc(m1);
+            assertEquals(m1.getName(), methodJavadoc1.getName());
+
+            String actualDesc = formatter.format(methodJavadoc1.getComment());
+            assertEquals("hoodwink a stranger", actualDesc);
+            assertEquals(1, methodJavadoc1.getParams().size());
+            assertFalse(methodJavadoc1.getReturns().getElements().isEmpty());
+            assertFalse(methodJavadoc1.getThrows().isEmpty());
+
+            final String methodName2 = "snaggle";
+            Method m2 = c.getDeclaredMethod(methodName2, String.class);
+            assertMethodDescriptionMatches(m2, "Snaggle a kerfluffin");
+        }
+    }
+
+    @Test
+    public void genericMethodsMatchWithImplementation() throws Exception {
+        try (CompilationClassLoader classLoader = compile(null)) {
+            Class<?> c = classLoader.loadClass(DOCUMENTED_IMPLEMENTATION);
+
+            final String methodName1 = "fling";
+
+            Method m1 = c.getDeclaredMethod(methodName1, Integer.class);
+
+            MethodJavadoc methodJavadoc1 = expectJavadoc(m1);
+            assertEquals(m1.getName(), methodJavadoc1.getName());
+            String actualDesc = formatter.format(methodJavadoc1.getComment());
+            assertEquals("Fling the tea", actualDesc);
+            assertEquals(1, methodJavadoc1.getParams().size());
+            assertFalse(methodJavadoc1.getReturns().getElements().isEmpty());
+            assertFalse(methodJavadoc1.getThrows().isEmpty());
+            assertEquals(methodJavadoc1.getParamTypes(), Arrays.asList("java.lang.Integer"));
+            assertEquals("the tea weight", formatter.format(methodJavadoc1.getParams().get(0).getComment()));
+
+            Method m2 = c.getDeclaredMethod(methodName1, Object.class);
+            expectNoJavadoc(m2);
+        }
+    }
+
+    @Test
+    public void methodsMatchOnInterface() throws Exception {
+        try (CompilationClassLoader classLoader = compile(null)) {
+            Class<?> c1 = classLoader.loadClass(DOCUMENTED_INTERFACE);
+            Class<?> c2 = classLoader.loadClass(OTHER_INTERFACE);
+
+            final String methodName1 = "hoodwink";
+            Method m1 = c1.getDeclaredMethod(methodName1, String.class);
+            Method m2 = c2.getDeclaredMethod(methodName1, String.class);
+
+            assertMethodDescriptionMatches(m1, "Hoodwink a kerfluffin");
+            assertMethodDescriptionMatches(m2, "Hoodwink a schmadragon");
+
+            final String methodName2 = "snaggle";
+            Method m3 = c1.getDeclaredMethod(methodName2, String.class);
+            assertMethodDescriptionMatches(m3, "Snaggle a kerfluffin");
+        }
+    }
+
+    @Test
+    public void genericMethodsMatchOnInterface() throws Exception {
+        try (CompilationClassLoader classLoader = compile(null)) {
+            Class<?> c1 = classLoader.loadClass(DOCUMENTED_INTERFACE);
+            Class<?> c2 = classLoader.loadClass(OTHER_INTERFACE);
+
+            final String methodName3 = "fling";
+            Method m4 = c1.getDeclaredMethod(methodName3, Number.class);
+            Method m5 = c2.getDeclaredMethod(methodName3, Number.class);
+            assertMethodDescriptionMatches(m4, "Fling the tea");
+            assertMethodDescriptionMatches(m5, "Fling the vorrdin");
+        }
+    }
+
+    @Test
+    public void methodsMatchOnMultipleImplementedInterface() throws Exception {
+        try (CompilationClassLoader classLoader = compile(null)) {
+            Class<?> c1 = classLoader.loadClass(COMPLEX_IMPLEMENTATION);
+
+            final String methodName1 = "hoodwink";
+            Method m1 = c1.getDeclaredMethod(methodName1, String.class);
+
+            assertMethodDescriptionMatches(m1, "Hoodwink a kerfluffin");
+
+            final String methodName2 = "snaggle";
+            Method m2 = c1.getDeclaredMethod(methodName2, String.class);
+            assertMethodDescriptionMatches(m2, "Snaggle a kerfluffin");
+        }
+    }
+
+    @Test
+    public void genericMethodsMatchOnMultipleImplementedInterface() throws Exception {
+        try (CompilationClassLoader classLoader = compile(null)) {
+            Class<?> c1 = classLoader.loadClass(COMPLEX_IMPLEMENTATION);
+
+            final String methodName3 = "fling";
+            Method m3 = c1.getDeclaredMethod(methodName3, Integer.class);
+            assertMethodDescriptionMatches(m3, "Fling the tea");
+        }
+    }
+
+    @Test
+    public void methodsMatchOnExtendedClassAndImplementedInterface() throws Exception {
+        try (CompilationClassLoader classLoader = compile(null)) {
+            Class<?> c1 = classLoader.loadClass(VERY_COMPLEX_IMPLEMENTATION);
+
+            final String methodName1 = "hoodwink";
+            Method m1 = c1.getDeclaredMethod(methodName1, String.class);
+
+            assertMethodDescriptionMatches(m1, "hoodwink a stranger");
+        }
+    }
+
+    @Test
+    public void genericMethodsMatchOnExtendedClassAndImplementedInterface() throws Exception {
+        try (CompilationClassLoader classLoader = compile(null)) {
+            Class<?> c1 = classLoader.loadClass(VERY_COMPLEX_IMPLEMENTATION);
+
+            final String methodName3 = "fling";
+            Method m2 = c1.getDeclaredMethod(methodName3, Integer.class);
+            assertMethodDescriptionMatches(m2, "Fling the tea");
         }
     }
 
@@ -273,6 +524,14 @@ public class JavadocAnnotationProcessorTest {
         assertEquals(seeAlso4.getSeeAlsoType(), SeeAlsoJavadoc.SeeAlsoType.HTML_LINK);
         assertEquals(seeAlso4.getHtmlLink().getLink(), "http://www.moomoo.land");
         assertEquals(seeAlso4.getHtmlLink().getText(), "Moomoo land");
+    }
+
+    private static void assertMethodDescriptionMatches(Method method, String expectedDescription) {
+        MethodJavadoc methodDoc = expectJavadoc(method);
+        assertEquals(method.getName(), methodDoc.getName());
+
+        String actualDesc = formatter.format(methodDoc.getComment());
+        assertEquals(expectedDescription, actualDesc);
     }
 
     @Test
@@ -372,6 +631,13 @@ public class JavadocAnnotationProcessorTest {
         assertNotNull(doc);
         assertTrue(doc.isEmpty());
         assertEquals(c.getName(), doc.getName());
+    }
+
+    private static void expectNoJavadoc(Method m) {
+        MethodJavadoc doc = RuntimeJavadoc.getJavadoc(m);
+        assertNotNull(doc);
+        assertTrue(doc.isEmpty());
+        assertEquals(m.getName(), doc.getName());
     }
 
     private static <T extends BaseJavadoc> T assertPresent(T value, String msg) {

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/bar/OverridingClassInAnotherPackage.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/bar/OverridingClassInAnotherPackage.java
@@ -1,0 +1,21 @@
+package javasource.bar;
+
+import java.util.List;
+import javasource.foo.DocumentedClass;
+
+
+// I override methods of DocumentedClass with and without their own javadoc
+public class OverridingClassInAnotherPackage extends DocumentedClass<Object> {
+
+  /**
+   * Quick frobulate {@code a} by {@code b} using thin frobulation
+   */
+  public int frobulate(String a, int b) {
+    throw new UnsupportedOperationException();
+  }
+
+  // I have no javadoc of my own
+  public int frobulate(String a, List<Integer> b) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/ComplexImplementation.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/ComplexImplementation.java
@@ -1,0 +1,20 @@
+package javasource.foo;
+
+import javasource.foo.OtherInterface;
+import javasource.foo.DocumentedInterface;
+
+public class ComplexImplementation implements DocumentedInterface<Integer>, OtherInterface<Integer> {
+    // I have no javadoc of my own
+    public boolean hoodwink(String i) {
+        throw new UnsupportedOperationException();
+    }
+
+    // I have no javadoc of my own
+    public boolean snaggle(String i) {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean fling(Integer v) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/DocumentedClass.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/DocumentedClass.java
@@ -9,7 +9,7 @@ import java.util.List;
  * @custom.tag What does {@custom.inline this} mean?
  */
 
-public class DocumentedClass {
+public class DocumentedClass<T> {
 
   /**
    * I'm a useful field, maybe.
@@ -17,6 +17,11 @@ public class DocumentedClass {
    * @see #frobulate(String, int) interesting method, but nothing to do with this field
    */
   private int myField;
+
+  /**
+   * I'm a field my children can see.
+   */
+  protected int ourField;
 
   /**
    * I'm a constructor!
@@ -73,11 +78,49 @@ public class DocumentedClass {
   }
 
   /**
+   * I am a simple method
+   *
+   * @throws UnsupportedOperationException if cannot skip
+   */
+  public void skipMethod() throws UnsupportedOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Foo {@link Foo#bar(String).}{@value Foo#bar(String).}
    *
    * @see Foo#bar(String).
    */
   public void malformedLinks() {
+  }
+
+  /**
+   * Generic method to do generic things
+   */
+  public T genericMethod(T generic) {
+    return generic;
+  }
+
+  /**
+   * Generic method to do run things
+   */
+  public T skipGenericMethod(T generic) {
+    return generic;
+  }
+
+  /**
+   * Generic method to do other things
+   */
+  public <U extends Comparable<U>> T separateGeneric(U otherGeneric) {
+    throw new UnsupportedOperationException();
+  }
+
+  public T blankGenericMethod() {
+    throw new UnsupportedOperationException();
+  }
+
+  public boolean equals(Object o) {
+    return super.equals(o);
   }
 
   /**

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/DocumentedImplementation.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/DocumentedImplementation.java
@@ -1,0 +1,28 @@
+package javasource.foo;
+
+import javasource.foo.DocumentedInterface;
+
+public class DocumentedImplementation implements DocumentedInterface<Integer> {
+    /**
+     * hoodwink a stranger
+     */
+    public boolean hoodwink(String i) {
+        throw new UnsupportedOperationException();
+    }
+
+    // I have no javadoc of my own
+    public boolean snaggle(String i) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @param v the tea weight
+     */
+    public boolean fling(Integer v) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean fling(Object v) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/DocumentedInterface.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/DocumentedInterface.java
@@ -1,0 +1,32 @@
+package javasource.foo;
+
+/**
+ * The {@code Javadoc} from this interface is used for testing
+ *
+ */
+public interface DocumentedInterface<T extends Number> {
+    /**
+     * Hoodwink a kerfluffin
+     *
+     * @param i innocent
+     * @return true if innocent hoodwinked
+     * @throws UnsupportedOperationException if hoodwinking cannot be performed
+     */
+    public boolean hoodwink(String i) throws UnsupportedOperationException;
+
+    /**
+     * Snaggle a kerfluffin
+     *
+     * @param i innocent
+     * @return true if innocent hoodwinked
+     */
+    public boolean snaggle(String i);
+
+    /**
+     * Fling the tea
+     * @param v
+     * @return true if flung
+     * @exception UnsupportedOperationException if hoodwinking cannot be performed
+     */
+    public boolean fling(T v) throws UnsupportedOperationException;
+}

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/OtherInterface.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/OtherInterface.java
@@ -1,0 +1,19 @@
+package javasource.foo;
+
+/**
+ * The {@code Javadoc} from this interface is used for masking
+ *
+ */
+public interface OtherInterface<T extends Number> {
+    /**
+     * Hoodwink a schmadragon
+     */
+    public boolean hoodwink(String g);
+
+    /**
+     * Fling the vorrdin
+     * @param v
+     * @return
+     */
+    public boolean fling(T v);
+}

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/OverridingClass.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/OverridingClass.java
@@ -1,0 +1,44 @@
+package javasource.foo;
+
+import java.util.List;
+import javasource.foo.DocumentedClass;
+
+
+// I override methods of DocumentedClass with and without their own javadoc
+public class OverridingClass extends DocumentedClass<String> {
+
+  /**
+   * Super frobulate {@code a} by {@code b} using extended frobulation
+   *
+   * @see com.github.therapi.runtimejavadoc.DocumentedClass Hey, that's this class!
+   * @see javasource.foo.DocumentedClass#someOtherMethod()
+   * @see "Moomoo boy went straight to Moomoo land. Land of the moomoo's"
+   * @see <a href="http://www.moomoo.land">Moomoo land</a>
+   */
+  public int frobulate(String a, int b) {
+    throw new UnsupportedOperationException();
+  }
+
+  // I have no javadoc of my own
+  public int frobulate(String a, List<Integer> b) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * My very own method
+   *
+   */
+  public void myOwnMethod() {
+    throw new UnsupportedOperationException();
+  }
+
+  // I have no javadoc
+  public String genericMethod(String generic) {
+    return generic;
+  }
+
+  // Even though I may no look like it I override nothing but do partially hide a method
+  public String separateGeneric(Integer otherGeneric) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/OverridingClass2Degrees.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/OverridingClass2Degrees.java
@@ -1,0 +1,20 @@
+package javasource.foo;
+
+import java.util.List;
+import javasource.foo.OverridingClass;
+
+
+// I override methods of DocumentedClass with and without their own javadoc
+public class OverridingClass2Degrees extends OverridingClass {
+
+  /**
+   * I am also a simple method
+   */
+  public void skipMethod() {
+    throw new UnsupportedOperationException();
+  }
+
+  public String skipGenericMethod(String generic) {
+    return generic;
+  }
+}

--- a/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/VeryComplexImplementation.java
+++ b/therapi-runtime-javadoc-scribe/src/test/resources/javasource/foo/VeryComplexImplementation.java
@@ -1,0 +1,15 @@
+package javasource.foo;
+
+import javasource.foo.OtherInterface;
+import javasource.foo.DocumentedInterface;
+
+public class VeryComplexImplementation extends DocumentedImplementation implements OtherInterface<Integer> {
+    // I have no javadoc of my own
+    public boolean hoodwink(String i) {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean fling(Integer v) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/ClassJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/ClassJavadoc.java
@@ -99,8 +99,7 @@ public class ClassJavadoc extends BaseJavadoc {
 
     ClassJavadoc createEnhancedClassJavadoc(Class<?> clazz) {
         if (!getName().equals(clazz.getCanonicalName())) {
-            throw new IllegalArgumentException(
-                    String.format("Class `%s` does not match class doc for `%s`", clazz, getName()));
+            throw new IllegalArgumentException("Class `" + clazz.getCanonicalName() + "` does not match class doc for `" + getName() + "`");
         }
 
         if (isEmpty()) {

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/ClassJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/ClassJavadoc.java
@@ -171,23 +171,13 @@ public class ClassJavadoc extends BaseJavadoc {
     @Override
     public String toString() {
         return "ClassJavadoc{"
-               + "name='"
-               + getName()
-               + '\''
-               + ", comment="
-               + getComment()
-               + ", fields="
-               + fields
-               + ", methods="
-               + methods
-               + ", constructors="
-               + constructors
-               + ", recordComponents="
-               + recordComponents
-               + ", seeAlso="
-               + getSeeAlso()
-               + ", other="
-               + getOther()
-               + '}';
+               + "name='" + getName() + '\''
+               + ", comment=" + getComment()
+               + ", fields=" + fields
+               + ", methods=" + methods
+               + ", constructors=" + constructors
+               + ", recordComponents=" + recordComponents
+               + ", seeAlso=" + getSeeAlso()
+               + ", other=" + getOther() + '}';
     }
 }

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/ClassJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/ClassJavadoc.java
@@ -42,32 +42,32 @@ public class ClassJavadoc extends BaseJavadoc {
                         List<SeeAlsoJavadoc> seeAlso, List<ParamJavadoc> recordComponents) {
         super(name, comment, seeAlso, other);
 
-        LinkedHashMap<String, FieldJavadoc> fieldMap = new LinkedHashMap<>();
+        Map<String, FieldJavadoc> fieldMap = new LinkedHashMap<>();
         if (fields != null) {
             fields.forEach(fieldJavadoc -> fieldMap.put(fieldJavadoc.getName(), fieldJavadoc));
         }
         this.fields = Collections.unmodifiableMap(fieldMap);
 
-        LinkedHashMap<String, FieldJavadoc> enumMap = new LinkedHashMap<>();
+        Map<String, FieldJavadoc> enumMap = new LinkedHashMap<>();
         if (enumConstants != null) {
             enumConstants.forEach(fieldJavadoc -> enumMap.put(fieldJavadoc.getName(), fieldJavadoc));
         }
         this.enumConstants = Collections.unmodifiableMap(enumMap);
 
-        LinkedHashMap<MethodJavadocKey, MethodJavadoc> methodsMap = new LinkedHashMap<>();
+        Map<MethodJavadocKey, MethodJavadoc> methodsMap = new LinkedHashMap<>();
         if (methods != null) {
             methods.forEach(methodJavadoc -> methodsMap.put(methodJavadoc.toMethodJavadocKey(), methodJavadoc));
         }
         this.methods = Collections.unmodifiableMap(methodsMap);
 
-        LinkedHashMap<MethodJavadocKey, MethodJavadoc> constructorsMap = new LinkedHashMap<>();
+        Map<MethodJavadocKey, MethodJavadoc> constructorsMap = new LinkedHashMap<>();
         if (constructors != null) {
             constructors.forEach(
                     methodJavadoc -> constructorsMap.put(methodJavadoc.toMethodJavadocKey(), methodJavadoc));
         }
         this.constructors = Collections.unmodifiableMap(constructorsMap);
 
-        LinkedHashMap<String, ParamJavadoc> recordsMap = new LinkedHashMap<>();
+        Map<String, ParamJavadoc> recordsMap = new LinkedHashMap<>();
         if (recordComponents != null) {
             recordComponents.forEach(paramJavadoc -> recordsMap.put(paramJavadoc.getName(), paramJavadoc));
         }

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/ClassJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/ClassJavadoc.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class ClassJavadoc extends BaseJavadoc {
     private final Map<String, FieldJavadoc> fields;

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/Comment.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/Comment.java
@@ -26,7 +26,7 @@ import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.un
  * Comment text that may contain inline tags.
  */
 public class Comment implements Iterable<CommentElement> {
-    private static final Comment EMPTY = new Comment(Collections.<CommentElement>emptyList());
+    private static final Comment EMPTY = new Comment(Collections.emptyList());
 
     public static Comment createEmpty() {
         return EMPTY;

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/MethodJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/MethodJavadoc.java
@@ -114,7 +114,7 @@ public class MethodJavadoc extends BaseJavadoc {
         return enhancedJavadoc;
     }
 
-    MethodJavadoc copyWithInheritance(MethodJavadoc superMethodJavadoc) {
+    private MethodJavadoc copyWithInheritance(MethodJavadoc superMethodJavadoc) {
         if (superMethodJavadoc.isEmpty()) {
             return this;
         }

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/MethodJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/MethodJavadoc.java
@@ -95,7 +95,26 @@ public class MethodJavadoc extends BaseJavadoc {
         };
     }
 
-    public MethodJavadoc copyWithInheritance(MethodJavadoc superMethodJavadoc) {
+    MethodJavadoc enhanceWithOverriddenJavadoc(Method method, Map<String, ClassJavadoc> classJavadocCache) {
+        MethodJavadoc enhancedJavadoc = this;
+        List<Class<?>> superTypes = RuntimeJavadocHelper.getAllTypeAncestors(method.getDeclaringClass());
+
+        for (Class<?> superType : superTypes) {
+            ClassJavadoc classJavadoc = classJavadocCache.get(superType.getCanonicalName());
+            if (classJavadoc == null) {
+                classJavadoc = RuntimeJavadoc.getSkinnyClassJavadoc(superType);
+            }
+            MethodJavadoc overriddenJavadoc = classJavadoc.findMatchingMethod(method);
+            enhancedJavadoc = enhancedJavadoc.copyWithInheritance(overriddenJavadoc);
+            if (enhancedJavadoc.fullyDescribes(method)) {
+                break;
+            }
+        }
+
+        return enhancedJavadoc;
+    }
+
+    MethodJavadoc copyWithInheritance(MethodJavadoc superMethodJavadoc) {
         if (superMethodJavadoc.isEmpty()) {
             return this;
         }

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/MethodJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/MethodJavadoc.java
@@ -150,12 +150,12 @@ public class MethodJavadoc extends BaseJavadoc {
         }
     }
 
-    private boolean matches(Method method) {
+    public boolean matches(Method method) {
         return method.getName().equals(getName())
                 && paramsMatch(method.getParameterTypes());
     }
 
-    private boolean matches(Constructor<?> method) {
+    public boolean matches(Constructor<?> method) {
         return isConstructor()
                 && paramsMatch(method.getParameterTypes());
     }

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/MethodJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/MethodJavadoc.java
@@ -17,6 +17,7 @@
 package com.github.therapi.runtimejavadoc;
 
 import com.github.therapi.runtimejavadoc.internal.MethodJavadocKey;
+import com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper;
 import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.unmodifiableDefensiveCopy;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
@@ -30,8 +31,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class MethodJavadoc extends BaseJavadoc {
-    public static final String INIT = "<init>";
-
     private final List<String> paramTypes;
     private final Map<String, ParamJavadoc> params;
     private final Map<String, ThrowsJavadoc> exceptions;
@@ -83,7 +82,7 @@ public class MethodJavadoc extends BaseJavadoc {
     }
 
     public static MethodJavadoc createEmpty(Executable executable) {
-        String name = executable instanceof Constructor ? INIT : executable.getName();
+        String name = executable instanceof Constructor ? RuntimeJavadocHelper.INIT : executable.getName();
         List<String> paramTypes = Arrays.stream(executable.getParameterTypes())
                                         .map(Class::getCanonicalName)
                                         .collect(Collectors.toList());
@@ -126,12 +125,12 @@ public class MethodJavadoc extends BaseJavadoc {
     }
 
     public boolean isConstructor() {
-        return INIT.equals(getName());
+        return RuntimeJavadocHelper.INIT.equals(getName());
     }
 
-    public boolean fullyDescribes(Method method) {
+    boolean fullyDescribes(Method method) {
         if (!method.getName().equals(getName()) || method.getParameterCount() != paramTypes.size()) {
-            throw new IllegalArgumentException(String.format("Method `%s` does not match javadoc `%s`", method, this));
+            throw new IllegalArgumentException("Method `" + method.getName() + "` does not match javadoc `" + getName() + "`");
         }
 
         return !getComment().getElements().isEmpty()

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/MethodJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/MethodJavadoc.java
@@ -16,17 +16,25 @@
 
 package com.github.therapi.runtimejavadoc;
 
+import com.github.therapi.runtimejavadoc.internal.MethodJavadocKey;
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.unmodifiableDefensiveCopy;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
-
-import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.unmodifiableDefensiveCopy;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class MethodJavadoc extends BaseJavadoc {
+    public static final String INIT = "<init>";
+
     private final List<String> paramTypes;
-    private final List<ParamJavadoc> params;
-    private final List<ThrowsJavadoc> exceptions;
+    private final Map<String, ParamJavadoc> params;
+    private final Map<String, ThrowsJavadoc> exceptions;
     private final Comment returns;
 
     public MethodJavadoc(String name,
@@ -38,14 +46,49 @@ public class MethodJavadoc extends BaseJavadoc {
                          Comment returns,
                          List<SeeAlsoJavadoc> seeAlso) {
         super(name, comment, seeAlso, other);
+
         this.paramTypes = unmodifiableDefensiveCopy(paramTypes);
-        this.params = unmodifiableDefensiveCopy(params);
-        this.exceptions = unmodifiableDefensiveCopy(exceptions);
         this.returns = Comment.nullToEmpty(returns);
+
+        Map<String, ParamJavadoc> paramJavadocMap = new LinkedHashMap<>();
+
+        if (params != null) {
+            params.forEach(paramJavadoc -> paramJavadocMap.put(paramJavadoc.getName(), paramJavadoc));
+        }
+
+        this.params = Collections.unmodifiableMap(paramJavadocMap);
+
+        Map<String, ThrowsJavadoc> throwsJavadocMap = new LinkedHashMap<>();
+
+        if (params != null) {
+            exceptions.forEach(throwsJavadoc -> throwsJavadocMap.put(throwsJavadoc.getName(), throwsJavadoc));
+        }
+
+        this.exceptions = Collections.unmodifiableMap(throwsJavadocMap);
     }
 
-    public static MethodJavadoc createEmpty(Method method) {
-        return new MethodJavadoc(method.getName(), null, null, null, null, null, null, null) {
+    private MethodJavadoc(String name,
+                          List<String> paramTypes,
+                          Comment comment,
+                          Map<String, ParamJavadoc> params,
+                          Map<String, ThrowsJavadoc> exceptions,
+                          List<OtherJavadoc> other,
+                          Comment returns,
+                          List<SeeAlsoJavadoc> seeAlso) {
+        super(name, comment, seeAlso, other);
+        this.paramTypes = Collections.unmodifiableList(paramTypes);
+        this.params = Collections.unmodifiableMap(params);
+        this.exceptions = Collections.unmodifiableMap(exceptions);
+        this.returns = returns;
+    }
+
+    public static MethodJavadoc createEmpty(Executable executable) {
+        String name = executable instanceof Constructor ? INIT : executable.getName();
+        List<String> paramTypes = Arrays.stream(executable.getParameterTypes())
+                                        .map(Class::getCanonicalName)
+                                        .collect(Collectors.toList());
+
+        return new MethodJavadoc(name, paramTypes, null, (List<ParamJavadoc>) null, null, null, null, null) {
             @Override
             public boolean isEmpty() {
                 return true;
@@ -53,25 +96,67 @@ public class MethodJavadoc extends BaseJavadoc {
         };
     }
 
-    public static MethodJavadoc createEmpty(Constructor<?> method) {
-        return new MethodJavadoc("<init>", null, null, null, null, null, null, null) {
-            @Override
-            public boolean isEmpty() {
-                return true;
-            }
-        };
+    public MethodJavadoc copyWithInheritance(MethodJavadoc superMethodJavadoc) {
+        if (superMethodJavadoc.isEmpty()) {
+            return this;
+        }
+
+        List<String> paramTypes = new ArrayList<>(this.paramTypes);
+        if (paramTypes.isEmpty()) {
+            paramTypes = superMethodJavadoc.paramTypes;
+        }
+
+        Comment comment = getComment();
+        if (comment.getElements().isEmpty()) {
+            comment = superMethodJavadoc.getComment();
+        }
+
+        Map<String, ParamJavadoc> params = new LinkedHashMap<>(this.params);
+        superMethodJavadoc.params.forEach(params::putIfAbsent);
+
+        Map<String, ThrowsJavadoc> exceptions = new LinkedHashMap<>(this.exceptions);
+        superMethodJavadoc.exceptions.forEach(exceptions::putIfAbsent);
+
+        Comment returns = this.returns;
+        if (returns.getElements().isEmpty()) {
+            returns = superMethodJavadoc.returns;
+        }
+
+        return new MethodJavadoc(getName(), paramTypes, comment, params, exceptions, getOther(), returns, getSeeAlso());
     }
 
     public boolean isConstructor() {
-        return "<init>".equals(getName());
+        return INIT.equals(getName());
     }
 
-    public boolean matches(Method method) {
+    public boolean fullyDescribes(Method method) {
+        if (!method.getName().equals(getName()) || method.getParameterCount() != paramTypes.size()) {
+            throw new IllegalArgumentException(String.format("Method `%s` does not match javadoc `%s`", method, this));
+        }
+
+        return !getComment().getElements().isEmpty()
+               && !returns.getElements().isEmpty()
+               && method.getParameterCount() == params.size()
+               && Arrays.stream(method.getExceptionTypes())
+                        .allMatch(exception -> exceptions.containsKey(exception.getSimpleName()));
+    }
+
+    public boolean matches(Executable executable) {
+        if (executable instanceof Method) {
+            return matches((Method) executable);
+        } else if (executable instanceof Constructor) {
+            return matches((Constructor<?>) executable);
+        } else {
+            throw new UnsupportedOperationException("Unknown executable type");
+        }
+    }
+
+    private boolean matches(Method method) {
         return method.getName().equals(getName())
                 && paramsMatch(method.getParameterTypes());
     }
 
-    public boolean matches(Constructor<?> method) {
+    private boolean matches(Constructor<?> method) {
         return isConstructor()
                 && paramsMatch(method.getParameterTypes());
     }
@@ -88,16 +173,20 @@ public class MethodJavadoc extends BaseJavadoc {
         return methodParamsTypes;
     }
 
+    MethodJavadocKey toMethodJavadocKey() {
+        return new MethodJavadocKey(getName(), paramTypes);
+    }
+
     public List<String> getParamTypes() {
         return paramTypes;
     }
 
     public List<ParamJavadoc> getParams() {
-        return params;
+        return Collections.unmodifiableList(new ArrayList<>(params.values()));
     }
 
     public List<ThrowsJavadoc> getThrows() {
-        return exceptions;
+        return Collections.unmodifiableList(new ArrayList<>(exceptions.values()));
     }
 
     public Comment getReturns() {

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/RuntimeJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/RuntimeJavadoc.java
@@ -201,8 +201,7 @@ public class RuntimeJavadoc {
      * @return the given constructor's Javadoc
      */
     public static MethodJavadoc getJavadoc(Constructor<?> method) {
-        ClassJavadoc javadoc = getSkinnyClassJavadoc(method.getDeclaringClass());
-        return javadoc.findMatchingConstructor(method);
+        return getSkinnyClassJavadoc(method.getDeclaringClass()).findMatchingConstructor(method);
     }
 
     /**
@@ -220,8 +219,7 @@ public class RuntimeJavadoc {
      * @return the given field's Javadoc
      */
     public static FieldJavadoc getJavadoc(Field field) {
-        ClassJavadoc javadoc = getSkinnyClassJavadoc(field.getDeclaringClass());
-        return javadoc.findMatchingField(field);
+        return getSkinnyClassJavadoc(field.getDeclaringClass()).findMatchingField(field);
     }
 
     /**
@@ -239,7 +237,6 @@ public class RuntimeJavadoc {
      * @return the given enum constant's Javadoc
      */
     public static FieldJavadoc getJavadoc(Enum<?> enumValue) {
-        ClassJavadoc javadoc = getSkinnyClassJavadoc(enumValue.getDeclaringClass());
-        return javadoc.findMatchingEnumConstant(enumValue);
+        return getSkinnyClassJavadoc(enumValue.getDeclaringClass()).findMatchingEnumConstant(enumValue);
     }
 }

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/RuntimeJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/RuntimeJavadoc.java
@@ -174,7 +174,6 @@ public class RuntimeJavadoc {
         }
 
         methodJavadoc = methodJavadoc.enhanceWithOverriddenJavadoc(method, classJavadocCache);
-
         if (methodJavadoc.fullyDescribes(method)) {
             return methodJavadoc;
         }

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/RuntimeJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/RuntimeJavadoc.java
@@ -19,17 +19,19 @@ package com.github.therapi.runtimejavadoc;
 import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
 import com.github.therapi.runtimejavadoc.internal.JsonJavadocReader;
-
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.javadocResourceSuffix;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.List;
-
-import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.javadocResourceSuffix;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Allows access to Javadoc elements at runtime for code that was compiled using the
@@ -50,8 +52,8 @@ public class RuntimeJavadoc {
      * @param clazz the class whose Javadoc you want to retrieve
      * @return the Javadoc of the given class
      */
-    public static ClassJavadoc getJavadoc(Class clazz) {
-        return getJavadoc(clazz.getName(), clazz);
+    public static ClassJavadoc getJavadoc(Class<?> clazz) {
+        return getSkinnyClassJavadoc(clazz.getName(), clazz).createEnhancedClassJavadoc(clazz);
     }
 
     /**
@@ -74,14 +76,14 @@ public class RuntimeJavadoc {
      * {@link BaseJavadoc#isEmpty isEmpty()} method will return {@code true}.
      *
      * @param qualifiedClassName the fully qualified name of the class whose Javadoc you want to retrieve
-     * @param classLoader        the class loader to use to find the Javadoc resource file
+     * @param loader        the class loader to use to find the Javadoc resource file
      * @return the Javadoc of the given class
      */
-    public static ClassJavadoc getJavadoc(String qualifiedClassName, ClassLoader classLoader) {
-        final String resourceName = getResourceName(qualifiedClassName);
-        try (InputStream is = classLoader.getResourceAsStream(resourceName)) {
-            return parseJavadocResource(qualifiedClassName, is);
-        } catch (IOException e) {
+    public static ClassJavadoc getJavadoc(String qualifiedClassName, ClassLoader loader) {
+        try {
+            return getSkinnyClassJavadoc(qualifiedClassName, loader)
+                    .createEnhancedClassJavadoc(loader.loadClass(qualifiedClassName));
+        } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
     }
@@ -96,7 +98,31 @@ public class RuntimeJavadoc {
      * @param loader             the class object to use to find the Javadoc resource file
      * @return the Javadoc of the given class
      */
-    public static ClassJavadoc getJavadoc(String qualifiedClassName, Class loader) {
+    public static ClassJavadoc getJavadoc(String qualifiedClassName, Class<?> loader) {
+        try {
+            return getSkinnyClassJavadoc(qualifiedClassName, loader)
+                    .createEnhancedClassJavadoc(loader.getClassLoader().loadClass(qualifiedClassName));
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static ClassJavadoc getSkinnyClassJavadoc(Class<?> clazz) {
+        return getSkinnyClassJavadoc(clazz.getName(), clazz);
+    }
+
+    private static ClassJavadoc getSkinnyClassJavadoc(String qualifiedClassName, ClassLoader loader) {
+        System.out.printf("Getting %s%n", qualifiedClassName);
+        final String resourceName = getResourceName(qualifiedClassName);
+        try (InputStream is = loader.getResourceAsStream("/" + resourceName)) {
+            return parseJavadocResource(qualifiedClassName, is);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static ClassJavadoc getSkinnyClassJavadoc(String qualifiedClassName, Class<?> loader) {
+        System.out.printf("Getting %s%n", qualifiedClassName);
         final String resourceName = getResourceName(qualifiedClassName);
         try (InputStream is = loader.getResourceAsStream("/" + resourceName)) {
             return parseJavadocResource(qualifiedClassName, is);
@@ -135,8 +161,94 @@ public class RuntimeJavadoc {
      * @return the given method's Javadoc
      */
     public static MethodJavadoc getJavadoc(Method method) {
-        ClassJavadoc javadoc = getJavadoc(method.getDeclaringClass());
-        return findMethodJavadoc(javadoc.getMethods(), method);
+        return getJavadoc(method, Collections.emptyMap());
+    }
+
+    static MethodJavadoc getJavadoc(Method method, Map<String, ClassJavadoc> classJavadocCache) {
+        Class<?> declaringClass = method.getDeclaringClass();
+        ClassJavadoc classJavadoc = classJavadocCache.get(declaringClass.getCanonicalName());
+        if (classJavadoc == null) {
+            classJavadoc = getSkinnyClassJavadoc(declaringClass);
+        }
+
+        MethodJavadoc methodJavadoc = classJavadoc.findMatchingMethod(method);
+        if (methodJavadoc.fullyDescribes(method)) {
+            return methodJavadoc;
+        }
+
+        MethodJavadoc overriddenMethodJavadoc = findOverriddenMethodJavadoc(method, declaringClass, classJavadocCache);
+        methodJavadoc = methodJavadoc.copyWithInheritance(overriddenMethodJavadoc);
+
+        if (methodJavadoc.fullyDescribes(method)) {
+            return methodJavadoc;
+        }
+
+        Method bridgeMethod = findBridgeMethod(method);
+        if (bridgeMethod != null && method != bridgeMethod) {
+            MethodJavadoc bridgeMethodJavadoc = findOverriddenMethodJavadoc(bridgeMethod, declaringClass, classJavadocCache);
+            methodJavadoc = methodJavadoc.copyWithInheritance(bridgeMethodJavadoc);
+        }
+
+        return methodJavadoc;
+    }
+
+    private static MethodJavadoc findOverriddenMethodJavadoc(Method method, Class<?> searchedClass, Map<String, ClassJavadoc> classJavadocCache) {
+        List<Class<?>> superTypes = new ArrayList<>();
+        Class<?> superClass = searchedClass.getSuperclass();
+        if (superClass != null) {
+            superTypes.add(superClass);
+        }
+
+        superTypes.addAll(Arrays.asList(searchedClass.getInterfaces()));
+
+        for (Class<?> superType : superTypes) {
+            ClassJavadoc classJavadoc = classJavadocCache.get(superType.getCanonicalName());
+            if (classJavadoc == null) {
+                classJavadoc = getSkinnyClassJavadoc(superType);
+            }
+            MethodJavadoc methodJavadoc = classJavadoc.findMatchingMethod(method);
+            if (!methodJavadoc.fullyDescribes(method)) {
+                MethodJavadoc recursiveMethodJavadoc = findOverriddenMethodJavadoc(method, superType, classJavadocCache);
+                methodJavadoc = methodJavadoc.copyWithInheritance(recursiveMethodJavadoc);
+            }
+
+            if (!methodJavadoc.isEmpty()) {
+                return methodJavadoc;
+            }
+        }
+
+        return MethodJavadoc.createEmpty(method);
+    }
+
+    private static Method findBridgeMethod(Method method) {
+        if (method.isBridge()) {
+            return method;
+        }
+
+        Class<?> declaringClass = method.getDeclaringClass();
+        for (Method bridgeMethod : declaringClass.getDeclaredMethods()) {
+            if (bridgeMethod.isBridge()
+                && method.getName().equals(bridgeMethod.getName())
+                && parametersMatchWithErasure(method.getParameterTypes(), bridgeMethod.getParameterTypes())) {
+                return bridgeMethod;
+            }
+        }
+
+        return null;
+    }
+
+    private static boolean parametersMatchWithErasure(Class<?>[] parameterTypes, Class<?>[] erasureTypes) {
+        if (parameterTypes.length != erasureTypes.length) {
+            return false;
+        }
+
+        for (int i = 0; i < parameterTypes.length; i++) {
+            if (!erasureTypes[i].isAssignableFrom(parameterTypes[i])) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -154,26 +266,8 @@ public class RuntimeJavadoc {
      * @return the given constructor's Javadoc
      */
     public static MethodJavadoc getJavadoc(Constructor<?> method) {
-        ClassJavadoc javadoc = getJavadoc(method.getDeclaringClass());
-        return findMethodJavadoc(javadoc.getConstructors(), method);
-    }
-
-    private static MethodJavadoc findMethodJavadoc(List<MethodJavadoc> methodDocs, Method method) {
-        for (MethodJavadoc methodJavadoc : methodDocs) {
-            if (methodJavadoc.matches(method)) {
-                return methodJavadoc;
-            }
-        }
-        return MethodJavadoc.createEmpty(method);
-    }
-
-    private static MethodJavadoc findMethodJavadoc(List<MethodJavadoc> methodDocs, Constructor<?> method) {
-        for (MethodJavadoc methodJavadoc : methodDocs) {
-            if (methodJavadoc.matches(method)) {
-                return methodJavadoc;
-            }
-        }
-        return MethodJavadoc.createEmpty(method);
+        ClassJavadoc javadoc = getSkinnyClassJavadoc(method.getDeclaringClass());
+        return javadoc.findMatchingConstructor(method);
     }
 
     /**
@@ -191,8 +285,8 @@ public class RuntimeJavadoc {
      * @return the given field's Javadoc
      */
     public static FieldJavadoc getJavadoc(Field field) {
-        ClassJavadoc javadoc = getJavadoc(field.getDeclaringClass());
-        return findFieldJavadoc(javadoc.getFields(), field.getName());
+        ClassJavadoc javadoc = getSkinnyClassJavadoc(field.getDeclaringClass());
+        return javadoc.findMatchingField(field);
     }
 
     /**
@@ -210,16 +304,7 @@ public class RuntimeJavadoc {
      * @return the given enum constant's Javadoc
      */
     public static FieldJavadoc getJavadoc(Enum<?> enumValue) {
-        ClassJavadoc javadoc = getJavadoc(enumValue.getDeclaringClass());
-        return findFieldJavadoc(javadoc.getEnumConstants(), enumValue.name());
-    }
-
-    private static FieldJavadoc findFieldJavadoc(List<FieldJavadoc> fieldDocs, String fieldName) {
-        for (FieldJavadoc fDoc : fieldDocs) {
-            if (fDoc.getName().equals(fieldName)) {
-                return fDoc;
-            }
-        }
-        return FieldJavadoc.createEmpty(fieldName);
+        ClassJavadoc javadoc = getSkinnyClassJavadoc(enumValue.getDeclaringClass());
+        return javadoc.findMatchingEnumConstant(enumValue);
     }
 }

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/RuntimeJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/RuntimeJavadoc.java
@@ -112,7 +112,6 @@ public class RuntimeJavadoc {
     }
 
     private static ClassJavadoc getSkinnyClassJavadoc(String qualifiedClassName, ClassLoader loader) {
-        System.out.printf("Getting %s%n", qualifiedClassName);
         final String resourceName = getResourceName(qualifiedClassName);
         try (InputStream is = loader.getResourceAsStream("/" + resourceName)) {
             return parseJavadocResource(qualifiedClassName, is);
@@ -122,7 +121,6 @@ public class RuntimeJavadoc {
     }
 
     private static ClassJavadoc getSkinnyClassJavadoc(String qualifiedClassName, Class<?> loader) {
-        System.out.printf("Getting %s%n", qualifiedClassName);
         final String resourceName = getResourceName(qualifiedClassName);
         try (InputStream is = loader.getResourceAsStream("/" + resourceName)) {
             return parseJavadocResource(qualifiedClassName, is);

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/MethodJavadocKey.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/MethodJavadocKey.java
@@ -1,0 +1,40 @@
+package com.github.therapi.runtimejavadoc.internal;
+
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.unmodifiableDefensiveCopy;
+import java.util.List;
+import java.util.Objects;
+
+public class MethodJavadocKey {
+    private final String methodName;
+    private final List<String> methodParamTypes;
+
+    public MethodJavadocKey(String methodName, List<String> methodParamTypes) {
+        this.methodName = methodName;
+        this.methodParamTypes = unmodifiableDefensiveCopy(methodParamTypes);
+    }
+
+    public String getMethodName() {
+        return methodName;
+    }
+
+    public List<String> getMethodParamTypes() {
+        return methodParamTypes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MethodJavadocKey that = (MethodJavadocKey) o;
+        return Objects.equals(methodName, that.methodName) && Objects.equals(methodParamTypes, that.methodParamTypes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(methodName, methodParamTypes);
+    }
+}

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/RuntimeJavadocHelper.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/RuntimeJavadocHelper.java
@@ -16,7 +16,6 @@
 
 package com.github.therapi.runtimejavadoc.internal;
 
-import static com.github.therapi.runtimejavadoc.MethodJavadoc.INIT;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
@@ -29,6 +28,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class RuntimeJavadocHelper {
+    public static final String INIT = "<init>";
+
     private RuntimeJavadocHelper() {
         throw new AssertionError("not instantiable");
     }

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/JavadocParser.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/JavadocParser.java
@@ -24,7 +24,6 @@ import com.github.therapi.runtimejavadoc.OtherJavadoc;
 import com.github.therapi.runtimejavadoc.ParamJavadoc;
 import com.github.therapi.runtimejavadoc.SeeAlsoJavadoc;
 import com.github.therapi.runtimejavadoc.ThrowsJavadoc;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -45,92 +44,60 @@ public class JavadocParser {
 
     public static ClassJavadoc parseClassJavadoc(String className, String javadoc, List<FieldJavadoc> fields,
                                                  List<FieldJavadoc> enumConstants, List<MethodJavadoc> methods, List<MethodJavadoc> constructors) {
-        ParsedJavadoc parsed = parse(javadoc);
-
-        List<OtherJavadoc> otherDocs = new ArrayList<>();
-        List<SeeAlsoJavadoc> seeAlsoDocs = new ArrayList<>();
-        List<ParamJavadoc> paramDocs = new ArrayList<>();
-
-        for (BlockTag t : parsed.getBlockTags()) {
-            if (t.name.equals("param")) {
-                paramDocs.add(parseParam(t, className));
-            } else if (t.name.equals("see")) {
-                SeeAlsoJavadoc seeAlso = SeeAlsoParser.parseSeeAlso(className, t.value);
-                if (seeAlso != null) {
-                    seeAlsoDocs.add(seeAlso);
-                }
-            } else {
-                otherDocs.add(new OtherJavadoc(t.name, CommentParser.parse(className, t.value)));
-            }
-        }
-        return new ClassJavadoc(className, CommentParser.parse(className, parsed.getDescription()), fields, enumConstants, methods,
-                constructors, otherDocs, seeAlsoDocs, paramDocs);
+        ParsedJavadoc parsed = parse(javadoc, className);
+        return new ClassJavadoc(className, parsed.getDescription(), fields, enumConstants, methods,
+                constructors, parsed.getOtherDocs(), parsed.getSeeAlsoDocs(), parsed.getParamDocs());
     }
 
     public static FieldJavadoc parseFieldJavadoc(String owningClass, String fieldName, String javadoc) {
-        ParsedJavadoc parsed = parse(javadoc);
-
-        List<OtherJavadoc> otherDocs = new ArrayList<>();
-        List<SeeAlsoJavadoc> seeAlsoDocs = new ArrayList<>();
-
-        for (BlockTag t : parsed.getBlockTags()) {
-            if (t.name.equals("see")) {
-                SeeAlsoJavadoc seeAlso = SeeAlsoParser.parseSeeAlso(owningClass, t.value);
-                if (seeAlso != null) {
-                    seeAlsoDocs.add(seeAlso);
-                }
-            } else {
-                otherDocs.add(new OtherJavadoc(t.name, CommentParser.parse(owningClass, t.value)));
-            }
-        }
-
-        return new FieldJavadoc(fieldName, CommentParser.parse(owningClass, parsed.getDescription()), otherDocs, seeAlsoDocs);
+        ParsedJavadoc parsed = parse(javadoc, owningClass);
+        return new FieldJavadoc(fieldName, parsed.getDescription(), parsed.getOtherDocs(), parsed.getSeeAlsoDocs());
     }
 
     public static MethodJavadoc parseMethodJavadoc(String owningClass, String methodName, List<String> paramTypes, String javadoc) {
-        ParsedJavadoc parsed = parse(javadoc);
-
-        List<OtherJavadoc> otherDocs = new ArrayList<>();
-        List<SeeAlsoJavadoc> seeAlsoDocs = new ArrayList<>();
-        List<ParamJavadoc> paramDocs = new ArrayList<>();
-        List<ThrowsJavadoc> throwsDocs = new ArrayList<>();
-
-        Comment returns = null;
-
-        for (BlockTag t : parsed.getBlockTags()) {
-            if (t.name.equals("param")) {
-                paramDocs.add(parseParam(t, owningClass));
-            } else if (t.name.equals("return")) {
-                returns = CommentParser.parse(owningClass, t.value);
-            } else if (t.name.equals("see")) {
-                SeeAlsoJavadoc seeAlso = SeeAlsoParser.parseSeeAlso(owningClass, t.value);
-                if (seeAlso != null) {
-                    seeAlsoDocs.add(seeAlso);
-                }
-            } else if (t.name.equals("throws") || t.name.equals("exception")) {
-                ThrowsJavadoc throwsDoc = ThrowsTagParser.parseTag(owningClass, t.value);
-                if (throwsDoc != null) {
-                    throwsDocs.add(throwsDoc);
-                }
-            } else {
-                otherDocs.add(new OtherJavadoc(t.name, CommentParser.parse(owningClass, t.value)));
-            }
-        }
-
-        return new MethodJavadoc(methodName, paramTypes, CommentParser.parse(owningClass, parsed.getDescription()), paramDocs,
-                throwsDocs, otherDocs, returns, seeAlsoDocs);
+        ParsedJavadoc parsed = parse(javadoc, owningClass);
+        return new MethodJavadoc(methodName, paramTypes, parsed.getDescription(), parsed.getParamDocs(),
+                parsed.getThrowsDocs(), parsed.getOtherDocs(), parsed.getReturns(), parsed.getSeeAlsoDocs());
     }
 
-    private static ParsedJavadoc parse(String javadoc) {
+    private static ParsedJavadoc parse(String javadoc, String owningClass) {
         String[] blocks = blockSeparator.split(javadoc);
 
-        ParsedJavadoc result = new ParsedJavadoc();
-        result.description = blocks[0].trim();
+        List<ParamJavadoc> paramDocs = new ArrayList<>();
+        List<SeeAlsoJavadoc> seeAlsoDocs = new ArrayList<>();
+        List<ThrowsJavadoc> throwsDocs = new ArrayList<>();
+        List<OtherJavadoc> otherDocs = new ArrayList<>();
+        Comment returns = null;
 
         for (int i = 1; i < blocks.length; i++) {
-            result.blockTags.add(parseBlockTag(blocks[i]));
+            BlockTag blockTag = parseBlockTag(blocks[i]);
+            switch (blockTag.name) {
+                case "param":
+                    paramDocs.add(parseParam(blockTag, owningClass));
+                    break;
+                case "return":
+                    returns = CommentParser.parse(owningClass, blockTag.value);
+                    break;
+                case "see":
+                    SeeAlsoJavadoc seeAlso = SeeAlsoParser.parseSeeAlso(owningClass, blockTag.value);
+                    if (seeAlso != null) {
+                        seeAlsoDocs.add(seeAlso);
+                    }
+                    break;
+                case "throws":
+                case "exception":
+                    ThrowsJavadoc throwsDoc = ThrowsTagParser.parseTag(owningClass, blockTag.value);
+                    if (throwsDoc != null) {
+                        throwsDocs.add(throwsDoc);
+                    }
+                    break;
+                default:
+                    otherDocs.add(new OtherJavadoc(blockTag.name, CommentParser.parse(owningClass, blockTag.value)));
+                    break;
+            }
         }
-        return result;
+        Comment description = CommentParser.parse(owningClass, blocks[0].trim());
+        return new ParsedJavadoc(description, otherDocs, seeAlsoDocs, paramDocs, throwsDocs, returns);
     }
 
     private static BlockTag parseBlockTag(String block) {

--- a/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/ParsedJavadoc.java
+++ b/therapi-runtime-javadoc/src/main/java/com/github/therapi/runtimejavadoc/internal/parser/ParsedJavadoc.java
@@ -16,28 +16,67 @@
 
 package com.github.therapi.runtimejavadoc.internal.parser;
 
+import com.github.therapi.runtimejavadoc.Comment;
+import com.github.therapi.runtimejavadoc.OtherJavadoc;
+import com.github.therapi.runtimejavadoc.ParamJavadoc;
+import com.github.therapi.runtimejavadoc.SeeAlsoJavadoc;
+import com.github.therapi.runtimejavadoc.ThrowsJavadoc;
+import static com.github.therapi.runtimejavadoc.internal.RuntimeJavadocHelper.unmodifiableDefensiveCopy;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ParsedJavadoc {
+class ParsedJavadoc {
 
-    String description;
+    private final Comment description;
+    private final List<OtherJavadoc> otherDocs;
+    private final List<SeeAlsoJavadoc> seeAlsoDocs;
+    private final List<ParamJavadoc> paramDocs;
+    private final List<ThrowsJavadoc> throwsDocs;
+    private final Comment returns;
 
-    List<BlockTag> blockTags = new ArrayList<>();
+    ParsedJavadoc(Comment description, List<OtherJavadoc> otherDocs, List<SeeAlsoJavadoc> seeAlsoDocs,
+                         List<ParamJavadoc> paramDocs, List<ThrowsJavadoc> throwsDocs, Comment returns) {
+        this.description = description;
+        this.otherDocs = unmodifiableDefensiveCopy(otherDocs);
+        this.seeAlsoDocs = unmodifiableDefensiveCopy(seeAlsoDocs);
+        this.paramDocs = unmodifiableDefensiveCopy(paramDocs);
+        this.throwsDocs = unmodifiableDefensiveCopy(throwsDocs);
+        this.returns = Comment.nullToEmpty(returns);
+    }
 
     @Override
     public String toString() {
         return "ParsedJavadoc{" +
                 "description='" + description + '\'' +
-                ", blockTags=" + blockTags +
+                ", otherDocs=" + otherDocs +
+                ", seeAlsoDocs=" + seeAlsoDocs +
+                ", paramDocs=" + paramDocs +
+                ", throwsDocs=" + throwsDocs +
+                ", returns=" + returns +
                 '}';
     }
 
-    String getDescription() {
+    Comment getDescription() {
         return description;
     }
 
-    List<BlockTag> getBlockTags() {
-        return blockTags;
+    List<OtherJavadoc> getOtherDocs() {
+        return otherDocs;
+    }
+
+    List<SeeAlsoJavadoc> getSeeAlsoDocs() {
+        return seeAlsoDocs;
+    }
+
+    List<ParamJavadoc> getParamDocs() {
+        return paramDocs;
+    }
+
+    List<ThrowsJavadoc> getThrowsDocs() {
+        return throwsDocs;
+    }
+
+    Comment getReturns() {
+        return returns;
     }
 }


### PR DESCRIPTION
This adds javadoc from the overridden method in super class or interfaces if none is present on the declared method at runtime.
When a class is extended and/or multiple interfaces are implemented with the same signature priority returned by the super-class first then the interfaces in the order they are declared as is done by the javadoc command line tool

One of the potentially main issues I was not able to figure out was how to preserve the parameter order when inheriting java doc when some of the params are on the overriding method and some on the overridden. We don't have guaranteed access to the param names at runtime which makes it difficult to discern true order. Currently the inherited params are just added to the end of the list.

If the java doc is not complete then the missing parts are inherited from the overridden methods as described here https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html.

When loading a class javadoc all the methods are properly populated with inheritance. When loading just method javadoc only the necessary javadoc are loaded.

I changed the class javadoc to use a map in order to have more efficient method lookup. I left the getters to return list for the various components and the order is preserved from how they are inserted. It may be better to at some point change the return type to a collection as it can be a strict view, but at the moment this was not done in case dependent code expects a list.

Also something to consider is that in the annotation processor we erase all the type parameters so the param types of methods are limited to their bounds which can be seen on the generic method in Documented Class. However the javadoc tool actually preserves the generic type and bounds.

This did not cover the case of adding the javadoc from protected fields or parsing @ inheritdoc as I think these are a separate concern.

Let me know if you want any changes or see any holes.

Note this implementation does not require @ Override to be present on the method.

Note that when you generate javadoc for the VeryComplexImplementation it actually does not follow the algorithm provided [in the link.](https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html. It actually performs recursive search on the superclass first resulting in inheriting the javadoc for the fling method from DocumentedInterface rather than CompetingInterface as would be expected if the algorithm ran as described. So likely the order priority is something that changes with java versions unfortunately

Closes #61 